### PR TITLE
fix script names

### DIFF
--- a/bibliography.csv
+++ b/bibliography.csv
@@ -1,6 +1,6 @@
 script	collected	source	omniglot
 Cherokee	Anna Verdieva	Montgomery-Anderson, 2008: 31-107	http://www.omniglot.com/writing/cherokee.htm
-Mkhedruli(Georgian)	Antonina Sinelnik	Aronson, Howard I. (1990). Georgian: a reading grammar	http://www.omniglot.com/writing/georgian2.htm
+Mkhedruli (Georgian)	Antonina Sinelnik	Aronson, Howard I. (1990). Georgian: a reading grammar	http://www.omniglot.com/writing/georgian2.htm
 Hangul (Korean)	Antonina Sinelnik	"Lee, Hyun Bok (1999). ""Korean"". Handbook of the International Phonetic Association"	http://www.omniglot.com/writing/korean.htm
 Armenian	Antonina Sinelnik	Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian	http://www.omniglot.com/writing/armenian.htm
 Amharic	Anna Verdieva	Leslau, W. (1995). Reference grammar of Amharic. Otto Harrassowitz Verlag.	http://www.omniglot.com/writing/amharic.htm
@@ -13,9 +13,9 @@ Kalmyk	Vyacheslav Ivanov	Sanzheev G. D. (red.) Grammatika kalmytskogo yazyka. Fo
 Bashkir	Vyacheslav Ivanov	Yuldashev, A. A. (red.) (1981) Grammatika sovremennogo bashkirskogo literaturnogo yazyka. Moscow	http://www.omniglot.com/writing/cyrillic.htm
 Tibetan	Anna Verdieva	Tournade N. (2003) Manual of Standard Tibetan +AC0- Language and Civilization/ Nicolas Tournade, Sangda Dorje +AC0- Ithaca, NY: Snow Lion Publications.	http://www.omniglot.com/writing/tibetan.htm
 Tamil	Anna Verdieva	Andronov, M. S. (1965). The Tamil Language. Nauka.	http://www.omniglot.com/writing/tamil.htm
-Mongolian	Vyacheslav Ivanov	Todaeva, B. Kh. (1951) Grammatika sovremennogo mongolskogo yazika. Moscow	http://www.omniglot.com/writing/mongolian.htm
-Japanese Hiragana	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-hiragana.htm
-Japanese Katakana	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-katakana.htm
+Mongolian (Cyrillic)	Vyacheslav Ivanov	Todaeva, B. Kh. (1951) Grammatika sovremennogo mongolskogo yazika. Moscow	http://www.omniglot.com/writing/mongolian.htm
+Japanese (Hiragana)	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-hiragana.htm
+Japanese (Katakana)	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-katakana.htm
 Crimean Tatar	Vyacheslav Ivanov	Kavitskaya D. (2010) Crimean Tatar. Linkom Europa	https://www.omniglot.com/writing/crimeantatar.php
 Turkish	Vyacheslav Ivanov	Göksel A., Kerslake C. (2004) Turkish: A Comprehensive Grammar. London	https://www.omniglot.com/writing/turkish.htm
 Nganasan	Daria Demkina	Zhovnitskaja, S. N. (2009) Nganasanskij yazik. Krasnoyarsk	https://www.omniglot.com/writing/nganasan.htm
@@ -25,13 +25,13 @@ Pacoh	Daria Demkina	Watson R.,S., Canxóiq C. (2013) Pacoh – Vietnamese – En
 Kri	Daria Demkina	Enfield N. J., Diffloth G. (2009) Phonology and sketch grammar of Kri, a Vietic language of Laos. Cahiers de linguistique Asie orientale	http://omniglot.com/writing/kri.htm
 Wa	Daria Demkina	Mai M. S.(2012) A Descriptive Grammar of Wa. Payap University.	http://omniglot.com/writing/wa.htm
 Khmer	Daria Demkina	Gorgoniev Y. A. Grammatika khmerskogo jazyka [A grammar of the Khmer language] //Moskva: Izdatel’stvo Nauka. Decorative symmetry in ritual (and everyday) language. – 1966. – Т. 585.	NA
-Belorussian	Darya Zubova	Sjarzhuk, A. (2000) Govori so mnoj po-belorusski. Minsk	NA
-Bulgarian	Darya Zubova	Maslov, Yu. S. (1981) Grammatika bolgarskogo yazyka. Moscow	NA
+Belarusian 1	Darya Zubova	Sjarzhuk, A. (2000) Govori so mnoj po-belorusski. Minsk	NA
+Bulgarian 1	Darya Zubova	Maslov, Yu. S. (1981) Grammatika bolgarskogo yazyka. Moscow	NA
 Kazakh	Darya Zubova	Krippers, Karl A. (1997) Kazakh Grammar with Affix List	NA
 Kyrgyz	Darya Zubova	Kara, D. S. (2003) Kyrgyz, Lincom Europa	NA
 Tajik	Darya Zubova	Ido, Sh. (2005) Tajik, Lincom Europa	NA
 Uzbek	Darya Zubova	Ibragimov, S. I. (1972) Voprosy sovershenstvovaniya alfavitov tyurkskih yazykov SSSR, Moscow	NA
-Ukranian	Darya Zubova	Danyenko, A., Vakylenko, S. (1995) Ukranian, Lincom Europa, M_nchen-Newcastle	NA
+Ukrainian	Darya Zubova	Danyenko, A., Vakylenko, S. (1995) Ukranian, Lincom Europa, M_nchen-Newcastle	NA
 Serbian	Darya Zubova	Hammond, L. (2005) Serbian. An Essential Grammar. Routledge, London and New York	NA
 Macedonian	Darya Zubova	Friedman, V. (2001) Macedonian, SEELRC	NA
 Latvian	Darya Zubova	Mathiassen, T. (1996) A short grammar of Latvian, Slavica Publishers	NA
@@ -52,12 +52,12 @@ siSwati	Anna Simonyan	Corum, C. W. (1978). An Introduction to the Swazi (siSwati
 seTswana	Anna Simonyan	Peace Corps Botswana(2008). An Introduction to the Setswana Language	https://www.omniglot.com/writing/latin.htm
 chiTonga	Anna Simonyan	Carter, H., & Kashoki, M. E. (2002). An outline of Chitonga grammar. Bookworld Pub House.	https://www.omniglot.com/writing/latin.htm
 Tsonga	Anna Simonyan	Ouwehand, M. (1965). Everyday Tsonga. Swiss Mission in South Africa.	https://www.omniglot.com/writing/latin.htm
-Zulu	Anna Simonyan	Wilkes, A., & Nkosi, N. (2003). Zulu. Teach Yourself.	https://www.omniglot.com/writing/latin.htm
+Zulu 1	Anna Simonyan	Wilkes, A., & Nkosi, N. (2003). Zulu. Teach Yourself.	https://www.omniglot.com/writing/latin.htm
 Xhosa	Anna Simonyan	Kirsch, B., Skorge, S., & Magona, S. (2003). Teach Yourself Xhosa. Hodder Headline.	https://www.omniglot.com/writing/latin.htm
 Afrikaans	Anna Simonyan	McDermott, L. (2005). Teach Yourself Afrikaans. NTC Publishing Group.	https://www.omniglot.com/writing/latin.htm
-Belarusian	Violetta Ivanova	Peter Mayo. Belorussian. Bernard Comrie, Greville C. Corbett (eds.) The Slavonic Languages. London and New York, 1993.	http://www.omniglot.com/writing/belarusian.htm
+Belarusian 2	Violetta Ivanova	Peter Mayo. Belorussian. Bernard Comrie, Greville C. Corbett (eds.) The Slavonic Languages. London and New York, 1993.	http://www.omniglot.com/writing/belarusian.htm
 Ukrainian	Violetta Ivanova	Stefan M. Pugh and Ian Press. Ukrainian. A comprehensive grammar. 1999	https://www.omniglot.com/writing/ukrainian.htm
-Bulgarian	Violetta Ivanova	Ernest A. Scatton. Bulgarian. Bernard Comrie, Greville G. Corbett (eds.). The slavonic languages. 1993	https://www.omniglot.com/writing/bulgarian.htm
+Bulgarian 2	Violetta Ivanova	Ernest A. Scatton. Bulgarian. Bernard Comrie, Greville G. Corbett (eds.). The slavonic languages. 1993	https://www.omniglot.com/writing/bulgarian.htm
 Russian	Violetta Ivanova	Князев С.В., Пожарицкая С.К. Современный русский литературный язык. Фонетика, орфоэпия, графика и орфография. М.: Гаудеамус, 2011.	https://www.omniglot.com/writing/russian.htm
 Polish	Violetta Ivanova	Sadowska. Polish. A Comprehensive Grammar. Routledge: London and New York. 2012.	https://www.omniglot.com/writing/polish.htm
 Czech	Violetta Ivanova	Laura A. Janda and Charles E. Towsend. Czech. 2000	https://www.omniglot.com/writing/czech.htm
@@ -92,9 +92,9 @@ Tigrinya	Irina Astafyeva	Mason, J. S. (Ed.). (1996). Tigrinya grammar. Red Sea P
 Tigre Geez	Irina Astafyeva	Raz, S. (1983). Tigre grammar and texts (Vol. 4). Undena Publications.	http://www.omniglot.com/writing/tigre.htm
 Ainu Katakana	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	NA
 Ainu Latin	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	NA
-Aymar	Alina Tillabayeva	Hardman, Martha James, Juana Vásquez, and Juan de Dios Yapita. Aymara Grammatical Sketch: To Be Used with Aymar Ar Yatiqañataki. Gainesville, Fla: Aymara Language Materials Project, Dept. of Anthropology, University of Florida, 1971.	https://www.omniglot.com/writing/aymara.htm
+Aymara	Alina Tillabayeva	Hardman, Martha James, Juana Vásquez, and Juan de Dios Yapita. Aymara Grammatical Sketch: To Be Used with Aymar Ar Yatiqañataki. Gainesville, Fla: Aymara Language Materials Project, Dept. of Anthropology, University of Florida, 1971.	https://www.omniglot.com/writing/aymara.htm
 Paraguayan Guarani	Alina Tillabayeva	Estigarribia, B. (2017). A Grammar Sketch of Paraguayan Guarani. Guarani linguistics in the 21st century, 7-85.	https://www.omniglot.com/writing/guarani.htm
-Kichwa (Kichwa Shimi / Runa Shimi)	Alina Tillabayeva	"Натаров А. Н. (2013) Грамматика языка кечуа
+Kichwa	Alina Tillabayeva	"Натаров А. Н. (2013) Грамматика языка кечуа
 "	https://omniglot.com/writing/kichwa.htm
 Arawak	Alina Tillabayeva	Pet, W. (2011). A grammar sketch and lexicon of Arawak (Lokono Dian). SIL e-Books, 30.	https://www.omniglot.com/writing/arawak.htm
 Swahili	Asya Simonyan	Russell, J. (1996). Swahili (Teach Yourself).	
@@ -130,7 +130,7 @@ Dhivehi (Thaana)	Anna Sorokina	Gnanadesikan, A. E., (2012). Maldivian Thaana, Ja
 Welsh	Tanya Masumi	Awbery G. Welsh. – na, 2009.	https://www.omniglot.com/writing/welsh.htm
 Breton	Tanya Masumi	Press I., Bihan H. Colloquial Breton: The complete course for beginners //FORUM FOR MODERN LANGUAGE STUDIES. – GREAT CLARENDON ST, OXFORD OX2 6DP, ENGLAND : OXFORD UNIV PRESS, 2005.	https://www.omniglot.com/writing/breton.htm
 Cornish	Tanya Masumi	Smith A. S. D., Hooper E. G. R. Cornish simplified: short lessons for self-tuition: pronunciation, grammar, exercises. – Dyllansow Truran, 1972.	https://www.omniglot.com/writing/cornish.htm
-Scottish	Tanya Masumi	Gillies W. Scottish Gaelic //The Celtic Languages. – Routledge, 2009. – С. 244-318.	https://www.omniglot.com/writing/gaelic.htm
+Scottish Gaelic	Tanya Masumi	Gillies W. Scottish Gaelic //The Celtic Languages. – Routledge, 2009. – С. 244-318.	https://www.omniglot.com/writing/gaelic.htm
 Irish	Tanya Masumi	Doyle A. Irish, volume 201 of Languages of the World/Materials //Munich, Germany: LINCOM EUROPA. – 2001.	https://www.omniglot.com/writing/irish.htm
 Manx	Tanya Masumi	Broderick G. Manx //The Celtic Languages. – Routledge, 2009. – С. 319-370.	https://www.omniglot.com/writing/manx.htm
 Italian	Tanya Masumi	Sandro Carnevali, Fonetica della lingua italiana  (1998-2007)	https://www.omniglot.com/writing/italian.htm
@@ -152,7 +152,7 @@ German	Violetta Ivanova	Bruce Donaldson. German. An Essential Grammar. Routledge
 Dutch	Violetta Ivanova	Gerdi Quist, Dennis Strik. Teach Yourself Dutch. 2003	https://www.omniglot.com/writing/dutch.htm
 English (BrE)	Violetta Ivanova	Michael Swan. Practical English Usage. Oxford University Press, 2009	https://www.omniglot.com/writing/english.htm
 English (BrE)	Violetta Ivanova	Rebecca M. Dauer. Accurate English: a complete course in pronunciation. Prentice Hall Regents, 1993.	https://www.omniglot.com/writing/english.htm
-Idish	Violetta Ivanova	Dovid Katz. Grammar of the Yiddish Language. Duckworth, 1987.	https://www.omniglot.com/writing/yiddish.htm
+Yiddish	Violetta Ivanova	Dovid Katz. Grammar of the Yiddish Language. Duckworth, 1987.	https://www.omniglot.com/writing/yiddish.htm
 Finnish	Irina Astafyeva	https://www.scribd.com/doc/316881341/Teach-Yourself-Finnish-1-pdf#fullscreen=1	http://www.omniglot.com/writing/finnish.htm
 Moksha	Irina Astafyeva	Поляков О. Е. Русско-мокшанский разговорник //Саранск: Мордов. кн. изд-во. – 1993.	http://www.omniglot.com/writing/moksha.htm
 Ter Sami	Irina Astafyeva	Куруч Р. Д. Краткий грамматический очерк саамского языка //РД Куруч (ред.). Саамско-русский словарь. М: Русский язык. – 1985. – С. 529-567.	http://www.omniglot.com/writing/tersami.htm
@@ -161,7 +161,7 @@ Udmurt	Irina Astafyeva	"И. В. Тараканов. Алфавит. — Удму
 Nganasan	Irina Astafyeva	Жовницкая-Турдагина С. Н. Ня’’ букварь. СПб., 1999.	http://www.omniglot.com/writing/nganasan.htm
 Ingrian	Irina Astafyeva	http://lingvisto.org/files/ingrian.pdf	http://www.omniglot.com/writing/ingrian.htm
 Erzya	Irina Astafyeva	Г. Аитов. Новый алфавит. Великая революция на востоке. — Саратов: Нижневолжское краевое изд-во, 1932. — С. 61-64. — 73 с. — 3150 экз.	http://www.omniglot.com/writing/erzya.htm
-Voro (Uralic)	Irina Astafyeva	https://linguapedia.info/languages/voro.html	http://www.omniglot.com/writing/voro.htm
+Võro	Irina Astafyeva	https://linguapedia.info/languages/voro.html	http://www.omniglot.com/writing/voro.htm
 Northern Sami	Irina Astafyeva	Svonni, E Mikael. Sámegiel-ruoŧagiel skuvlasátnelistu. — Sámiskuvlastivra, 1984. — P. III.	http://www.omniglot.com/writing/northernsami.htm
 Skolt Sami	Irina Astafyeva	Korhonen, Mikko. Mosnikoff, Jouni. Sammallahti, Pekka. Koltansaamen opas. Castreanumin toimitteita, Helsinki 1973.	http://www.omniglot.com/writing/skoltsami.htm
 Karelian	Irina Astafyeva	Zajkov P. M. Grammatika karelĘąskogo jazyka:(fonetika i morfologija). – Periodika, 1999.	http://www.omniglot.com/writing/karelian.htm
@@ -174,7 +174,7 @@ Inuktitut	Roman Tarasov	Rogers (2005) Writing Systems: a Linguistic Approach. pp
 Bambara	Roman Tarasov	Doumboya (2012) Illustrated English/N'ko Alphabet: An Introduction to N'ko for English Speakers.	http://omniglot.com/writing/nko.htm
 Mongolian	Roman Tarasov	Bat-Ireedui (2015) Colloquial Mongolian. The Complete Course for Beginners	http://omniglot.com/writing/mongolian.htm
 Hanuno'o	Roman Tarasov	Conklin (1953) Hanunóo-English Vocabulary. Berkeley & Los-Angeles	http://omniglot.com/writing/hanunoo.htm
-Zulu	Roman Tarasov	Doke. Vilakazi (1972) Zulu-English Dictionary. Johannesburg	https://omniglot.com/writing/zulu.htm
+Zulu 2	Roman Tarasov	Doke. Vilakazi (1972) Zulu-English Dictionary. Johannesburg	https://omniglot.com/writing/zulu.htm
 Persian Braille	Roman Tarasov	UNESCO (2013) World Braille Usage. Washington,D.C.	https://omniglot.com/writing/braille.htm
 Itbayat	Nikita Shennikov	Cesar A. Hidalgo, A Tagmemic Grammar of Ivatan, 1971	
 Tao	Nikita Shennikov	Rau, D. Victoria, Maa-Neu Dong,  Yami texts with reference grammar and dictionary, 2006	

--- a/database.csv
+++ b/database.csv
@@ -2839,316 +2839,316 @@ Tamil,ூ,uː,with ட் ம் ர் ழ் ள்,"M. S. Andronov, 1965: 14-
 Tamil,ூ,uː,with ங் ப் ய் வ்,"M. S. Andronov, 1965: 14-20",http://www.omniglot.com/writing/tamil.htm
 Tamil,ூ,uː,with ச்,"M. S. Andronov, 1965: 14-20",http://www.omniglot.com/writing/tamil.htm
 Tamil,ூ,uː,with க்,"M. S. Andronov, 1965: 14-20",http://www.omniglot.com/writing/tamil.htm
-Mongolian cyrillic,А,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Аа,aː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,а,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,аа,аː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,В,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,в,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,З,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,з,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,И,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,и,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,иа,aː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ио,oː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,М,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,м,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,н,ŋ,"в абсолютном конце слова, а также  перед г",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,О,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,о,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,П,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,п,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,С,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,с,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,У,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,у,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ы,ɯ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Japanese Hiragana,あ,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,い,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,う,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,え,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,お,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,か,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,き,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,く,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,け,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,こ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,さ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,し,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,す,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,せ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,そ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,た,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ち,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,つ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,て,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,と,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,な,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,に,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぬ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ね,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,の,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,は,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ふ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,へ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ほ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ま,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,み,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,む,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,め,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,も,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,や,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ゆ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,よ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ら,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,り,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,る,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,れ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ろ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,わ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,を,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ん,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,が,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぐ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,げ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ご,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ざ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ず,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぜ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぞ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,だ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,づ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,で,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ど,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ば,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,び,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぶ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,べ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぼ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぱ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぷ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぺ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぽ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,きゃ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,きゅ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,きょ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎゃ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎゅ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎょ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,しゃ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,しゅ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,しょ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ちゃ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ちゅ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ちょ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,にゃ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,にゅ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,にょ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひゃ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひゅ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひょ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴゃ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴゅ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴょ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,びゃ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,びゅ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,びょ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,みゃ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,みゅ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,みょ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,りゃ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,りゅ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,りょ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Katakana,ア,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Katakana,イ,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ウ,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,エ,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,オ,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,カ,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キ,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ク,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ケ,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,コ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,サ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,シ,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ス,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,セ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ソ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,タ,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チ,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ツ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,テ,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ト,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ナ,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニ,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヌ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ネ,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ノ,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ハ,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,フ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヘ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ホ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,マ,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミ,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ム,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,メ,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,モ,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヤ,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ユ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヨ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ラ,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リ,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ル,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,レ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ロ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ワ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヲ,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ン,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ガ,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,グ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゲ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゴ,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ザ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゼ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゾ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ダ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,デ,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ド,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,バ,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビ,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ブ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ベ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ボ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,パ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,プ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ペ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ポ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キャ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キュ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キョ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギャ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギュ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギョ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,シャ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,シュ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ショ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チャ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チュ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チョ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニャ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニュ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニョ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒャ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒュ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒョ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピャ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピュ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピョ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビャ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビュ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビョ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミャ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミュ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミョ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リャ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リュ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リョ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Mongolian (Cyrillic),А,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Аа,aː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),а,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),аа,аː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),В,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),в,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),З,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),з,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),И,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),и,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),иа,aː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ио,oː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),М,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),м,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),н,ŋ,"в абсолютном конце слова, а также  перед г",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),О,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),о,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),П,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),п,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),С,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),с,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),У,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),у,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ы,ɯ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Japanese (Hiragana),あ,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),い,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),う,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),え,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),お,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),か,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),き,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),く,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),け,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),こ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),さ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),し,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),す,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),せ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),そ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),た,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ち,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),つ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),て,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),と,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),な,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),に,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぬ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ね,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),の,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),は,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ふ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),へ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ほ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ま,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),み,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),む,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),め,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),も,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),や,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ゆ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),よ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ら,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),り,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),る,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),れ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ろ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),わ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),を,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ん,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),が,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぐ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),げ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ご,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ざ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ず,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぜ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぞ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),だ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),づ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),で,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ど,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ば,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),び,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぶ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),べ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぼ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぱ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぷ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぺ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぽ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),きゃ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),きゅ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),きょ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎゃ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎゅ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎょ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),しゃ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),しゅ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),しょ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ちゃ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ちゅ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ちょ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),にゃ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),にゅ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),にょ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひゃ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひゅ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひょ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴゃ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴゅ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴょ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),びゃ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),びゅ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),びょ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),みゃ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),みゅ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),みょ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),りゃ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),りゅ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),りょ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Katakana),ア,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Katakana),イ,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ウ,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),エ,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),オ,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),カ,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キ,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ク,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ケ,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),コ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),サ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),シ,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ス,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),セ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ソ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),タ,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チ,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ツ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),テ,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ト,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ナ,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニ,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヌ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ネ,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ノ,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ハ,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),フ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヘ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ホ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),マ,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミ,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ム,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),メ,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),モ,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヤ,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ユ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヨ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ラ,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リ,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ル,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),レ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ロ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ワ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヲ,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ン,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ガ,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),グ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゲ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゴ,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ザ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゼ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゾ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ダ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),デ,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ド,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),バ,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビ,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ブ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ベ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ボ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),パ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),プ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ペ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ポ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キャ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キュ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キョ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギャ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギュ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギョ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),シャ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),シュ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ショ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チャ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チュ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チョ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニャ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニュ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニョ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒャ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒュ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒョ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピャ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピュ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピョ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビャ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビュ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビョ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミャ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミュ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミョ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リャ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リュ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リョ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
 Crimean Tatar,А,a,,Kavitskaya 2010: 5-17,https://www.omniglot.com/writing/crimeantatar.php
 Crimean Tatar,а,a,,Kavitskaya 2010: 5-17,https://www.omniglot.com/writing/crimeantatar.php
 Crimean Tatar,Б,b,,Kavitskaya 2010: 5-17,https://www.omniglot.com/writing/crimeantatar.php
@@ -3803,7 +3803,7 @@ Kri,p,p,На конце слова pˀ,"Enfield, Diffloth 2009: 8-34",http://omn
 Kri,ph,pʰ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,qj,ʄ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,R,r~ʐ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
-kri,r,r~ʐ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
+Kri,r,r~ʐ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,S,s,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,s,s,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,T,t,На конце слова tˀ,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
@@ -6873,143 +6873,143 @@ Lower Sorbian,ž,ʒ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com
 Lower Sorbian,ž,ʃ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
 Lower Sorbian,Ź,ʑ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
 Lower Sorbian,ź,ʑ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
-Persian ,ـئ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian , ـؤ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـأ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـئـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ئـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian , أ,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ء,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـا,ɒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,آ ,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian , ا,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـب,b,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـبـ,b,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,بـ,b,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ب,b,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـپ,p,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـپـ,p,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,پـ,p,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,پ,p,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـت,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـتـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,تـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ت,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـث,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـثـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ثـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ث,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـج,d͡ʒ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـجـ,d͡ʒ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,جـ,d͡ʒ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ج,d͡ʒ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـچ,t͡ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـچـ,t͡ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,چـ,t͡ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,چ,t͡ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـح,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـحـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,حـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ح,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـخ,x,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـخـ,x,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,خـ,x,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,خ,x,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـد,d,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,د,d,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـذ,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ذ,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـر,ɾ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ر,ɾ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـز,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ز,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـژ,ʒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ژ,ʒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـس,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـسـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,سـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,س,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـش,ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـشـ,ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,شـ,ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ش,ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـص,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـصـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,صـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ص,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـض,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـضـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ضـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ض,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـط,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـطـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,طـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ط,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـظ,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـظـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ظـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ظ,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـع,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـعـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,عـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ع,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـغ,ɣ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـغـ,ɣ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,غـ,ɣ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,غ,ɣ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـف,f,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـفـ,f,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,فـ,f,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ف,f,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـق,ɢ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـقـ,ɢ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,قـ,ɢ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ق,ɢ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـک,k,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـکـ,k,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,کـ,k,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ک,k,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـگ,ɡ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـگـ,ɡ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,گـ,ɡ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,گ,ɡ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـل,l,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـلـ,l,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,لـ,l,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ل,l,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـم,m,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـمـ,m,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,مـ,m,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,م,m,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـن,n,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـنـ,n,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,نـ,n,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ن,n,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,v,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,ow,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,u,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,o,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,و,v,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,و,u,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,و,ow,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـه,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـه,e,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـه,a,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـهـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,هـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ه,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـی,y,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـی,i,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـی,ey,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـیـ,y,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـیـ,i,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـیـ,ey,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,یـ,y,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,یـ,i,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,یـ,ey,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ی,y,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ی,i,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ی,ey,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـئ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian, ـؤ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـأ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـئـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ئـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian, أ,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ء,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـا,ɒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,آ ,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian, ا,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـب,b,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـبـ,b,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,بـ,b,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ب,b,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـپ,p,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـپـ,p,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,پـ,p,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,پ,p,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـت,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـتـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,تـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ت,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـث,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـثـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ثـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ث,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـج,d͡ʒ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـجـ,d͡ʒ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,جـ,d͡ʒ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ج,d͡ʒ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـچ,t͡ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـچـ,t͡ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,چـ,t͡ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,چ,t͡ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـح,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـحـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,حـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ح,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـخ,x,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـخـ,x,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,خـ,x,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,خ,x,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـد,d,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,د,d,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـذ,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ذ,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـر,ɾ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ر,ɾ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـز,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ز,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـژ,ʒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ژ,ʒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـس,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـسـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,سـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,س,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـش,ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـشـ,ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,شـ,ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ش,ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـص,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـصـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,صـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ص,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـض,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـضـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ضـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ض,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـط,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـطـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,طـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ط,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـظ,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـظـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ظـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ظ,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـع,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـعـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,عـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ع,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـغ,ɣ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـغـ,ɣ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,غـ,ɣ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,غ,ɣ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـف,f,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـفـ,f,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,فـ,f,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ف,f,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـق,ɢ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـقـ,ɢ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,قـ,ɢ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ق,ɢ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـک,k,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـکـ,k,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,کـ,k,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ک,k,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـگ,ɡ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـگـ,ɡ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,گـ,ɡ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,گ,ɡ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـل,l,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـلـ,l,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,لـ,l,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ل,l,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـم,m,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـمـ,m,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,مـ,m,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,م,m,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـن,n,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـنـ,n,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,نـ,n,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ن,n,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,v,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,ow,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,u,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,o,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,و,v,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,و,u,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,و,ow,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـه,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـه,e,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـه,a,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـهـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,هـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ه,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـی,y,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـی,i,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـی,ey,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـیـ,y,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـیـ,i,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـیـ,ey,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,یـ,y,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,یـ,i,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,یـ,ey,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ی,y,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ی,i,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ی,ey,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
 Tadjik,А,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
 Tadjik,а,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
 Tadjik,Б,b,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
@@ -10125,70 +10125,70 @@ Ainu Katakana,ㇾ,-le,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Ainu Katakana,セ゚,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Ainu Katakana,ツ゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Ainu Katakana,ト゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Aymar,A,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,I,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,J,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,K,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,K’,k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,L,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,M,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,N,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,P,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,P’,p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Q,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Q’,q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,R,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,S,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,T,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,T’,t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,U,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,W,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,X,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,a,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,i,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,j,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,k,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,k',k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,l,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,m,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,n,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p',p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,h,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p',q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,r,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,s,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,t,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p',t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,u,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,w,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,x,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,A,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,I,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,J,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,K,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,K’,k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,L,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,M,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,N,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,P,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,P’,p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Q,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Q’,q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,R,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,S,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,T,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,T’,t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,U,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,W,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,X,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,a,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,i,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,j,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,k,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,k',k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,l,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,m,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,n,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p',p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,h,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p',q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,r,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,s,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,t,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p',t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,u,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,w,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,x,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
 Paraguayan Guarani,A,a,,[Estigarribia 2017],https://www.omniglot.com/writing/guarani.htm
 Paraguayan Guarani,À,a,под ударением и не поседний слог,[Estigarribia 2017],https://www.omniglot.com/writing/guarani.htm
 Paraguayan Guarani,Ã,ã,,[Estigarribia 2017],https://www.omniglot.com/writing/guarani.htm
@@ -11861,136 +11861,136 @@ Dargwa,Ь,j,in russian loanwords,Абдуллаев 1954: 23-30.,https://www.omn
 Dargwa,Э,e,,Абдуллаев 1954: 23-30.,https://www.omniglot.com/writing/dargwa.htm
 Dargwa,Ю,ju,,Абдуллаев 1954: 23-30.,https://www.omniglot.com/writing/dargwa.htm
 Dargwa,Я,ə,,Абдуллаев 1954: 23-30.,https://www.omniglot.com/writing/dargwa.htm
-Kabardian (East Circassian),а,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),в,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),з,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),и,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),и,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),к,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),м,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),о,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),о,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ӏ,ʔ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ӏу,ʔʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),п,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),с,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),у,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),у,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),А,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),В,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),З,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),И,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),И,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),К,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),М,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),О,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),О,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),П,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),С,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),У,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),У,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,а,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,в,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,з,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,и,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,и,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,к,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,м,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,о,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,о,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ӏ,ʔ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ӏу,ʔʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,п,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,с,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,у,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,у,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,А,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,В,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,З,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,И,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,И,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,К,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,М,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,О,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,О,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,П,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,С,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,У,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,У,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
 Lak,а,a,,Schulze 2007: 3-4.,https://www.omniglot.com/writing/lak.htm
 Lak,аь,aˁ,,Schulze 2007: 3-4.,https://www.omniglot.com/writing/lak.htm
 Lak,б,b,,Schulze 2007: 3-4.,https://www.omniglot.com/writing/lak.htm
@@ -16225,90 +16225,90 @@ Southern Sami,X,h,заимствования,Vangberg 2009,http://www.omniglot.c
 Southern Sami,x,h,заимствования,Vangberg 2009,http://www.omniglot.com/writing/southernsami.htm
 Southern Sami,Z,dz,заимствования,Vangberg 2009,http://www.omniglot.com/writing/southernsami.htm
 Southern Sami,z,dz,заимствования,Vangberg 2009,http://www.omniglot.com/writing/southernsami.htm
-Nothern Sami,A,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,a,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,B,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,b,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,B,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,b,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,C,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,c,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,D,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,d,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,D,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,d,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,E,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,e,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,E,eː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,e,e:,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,F,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,f,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,G,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,g,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,G,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,g,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,H,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,h,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,I,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,i,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,I,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,i,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,I,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,i,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,J,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,j,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,K,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,k,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,K,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,k,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,L,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,l,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,M,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,m,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,N,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,n,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,O,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,o,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,O,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,o,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,P,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,p,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,P,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,p,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,R,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,r,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,S,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,s,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,T,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,t,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,T,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,t,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,T,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,t,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,U,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,u,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,U,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,u,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,V,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,v,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,A,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,a,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,B,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,b,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,B,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,b,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,C,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,c,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,D,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,d,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,D,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,d,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,E,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,e,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,E,eː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,e,e:,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,F,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,f,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,G,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,g,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,G,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,g,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,H,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,h,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,I,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,i,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,I,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,i,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,I,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,i,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,J,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,j,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,K,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,k,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,K,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,k,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,L,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,l,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,M,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,m,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,N,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,n,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,O,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,o,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,O,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,o,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,P,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,p,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,P,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,p,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,R,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,r,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,S,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,s,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,T,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,t,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,T,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,t,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,T,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,t,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,U,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,u,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,U,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,u,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,V,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,v,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
 Skolt Sami,A,ɑ,,"Korhonen, Mosnikoff, Sammallahti, Pekka 1973.",http://www.omniglot.com/writing/skoltsami.htm
 Skolt Sami,a,ɑ,,"Korhonen, Mosnikoff, Sammallahti, Pekka 1973.",http://www.omniglot.com/writing/skoltsami.htm
 Skolt Sami,Â,ɐ,,"Korhonen, Mosnikoff, Sammallahti, Pekka 1973.",http://www.omniglot.com/writing/skoltsami.htm


### PR DESCRIPTION
@agricolamz - I updated the database.script and bibliography.script fields so that they match (e.g. there were some typos, or lack of numerals in the case of multiple entries).

I wrote some checks here (not sure if you want these in the repo, but I will probably add some more tests as I start to inspect the data, which may be useful for corrections and if/when new data are added):

https://github.com/bambooforest/wwsd/blob/tests/tests.R

All script names in the database are accounted for in the bibliography. Note, however, that there are script names in the bibliography that don't appear in the database file (perhaps place holders?), including:

|script          |
|:----------|
|Catalan    |
|Chechen    |
|French     |
|Italian    |
|Moldovan   |
|Portuguese |
|Romanian   |
|Romansch   |
|Spanish    |

There are also two bib entries for `Aghul`:

https://github.com/agricolamz/wwsd/blob/master/bibliography.csv#L113-L114

but only one script in the database (seems to be a merge from two resources). I suggest then updating that into one row with two references in the `source` field. 

I've gathered the Glottocodes for all the languages now and I suppose I will add a column to the bibliography.csv, since that seems to be your index.

You'll notice in the tests that the omniglot fields also don't match between the bibliography and the database. I suggest that when I update the bibliography with the Glottocodes, and fix the omniglot urls, then I write a script that generates the omniglot fields from the bibliography into the database. 