### PR TITLE
Add lang codes

### DIFF
--- a/bibliography.csv
+++ b/bibliography.csv
@@ -1,6 +1,6 @@
 script	collected	source	omniglot
 Cherokee	Anna Verdieva	Montgomery-Anderson, 2008: 31-107	http://www.omniglot.com/writing/cherokee.htm
-Mkhedruli(Georgian)	Antonina Sinelnik	Aronson, Howard I. (1990). Georgian: a reading grammar	http://www.omniglot.com/writing/georgian2.htm
+Mkhedruli (Georgian)	Antonina Sinelnik	Aronson, Howard I. (1990). Georgian: a reading grammar	http://www.omniglot.com/writing/georgian2.htm
 Hangul (Korean)	Antonina Sinelnik	"Lee, Hyun Bok (1999). ""Korean"". Handbook of the International Phonetic Association"	http://www.omniglot.com/writing/korean.htm
 Armenian	Antonina Sinelnik	Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian	http://www.omniglot.com/writing/armenian.htm
 Amharic	Anna Verdieva	Leslau, W. (1995). Reference grammar of Amharic. Otto Harrassowitz Verlag.	http://www.omniglot.com/writing/amharic.htm
@@ -13,9 +13,9 @@ Kalmyk	Vyacheslav Ivanov	Sanzheev G. D. (red.) Grammatika kalmytskogo yazyka. Fo
 Bashkir	Vyacheslav Ivanov	Yuldashev, A. A. (red.) (1981) Grammatika sovremennogo bashkirskogo literaturnogo yazyka. Moscow	http://www.omniglot.com/writing/cyrillic.htm
 Tibetan	Anna Verdieva	Tournade N. (2003) Manual of Standard Tibetan +AC0- Language and Civilization/ Nicolas Tournade, Sangda Dorje +AC0- Ithaca, NY: Snow Lion Publications.	http://www.omniglot.com/writing/tibetan.htm
 Tamil	Anna Verdieva	Andronov, M. S. (1965). The Tamil Language. Nauka.	http://www.omniglot.com/writing/tamil.htm
-Mongolian	Vyacheslav Ivanov	Todaeva, B. Kh. (1951) Grammatika sovremennogo mongolskogo yazika. Moscow	http://www.omniglot.com/writing/mongolian.htm
-Japanese Hiragana	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-hiragana.htm
-Japanese Katakana	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-katakana.htm
+Mongolian (Cyrillic)	Vyacheslav Ivanov	Todaeva, B. Kh. (1951) Grammatika sovremennogo mongolskogo yazika. Moscow	http://www.omniglot.com/writing/mongolian.htm
+Japanese (Hiragana)	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-hiragana.htm
+Japanese (Katakana)	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-katakana.htm
 Crimean Tatar	Vyacheslav Ivanov	Kavitskaya D. (2010) Crimean Tatar. Linkom Europa	https://www.omniglot.com/writing/crimeantatar.php
 Turkish	Vyacheslav Ivanov	Göksel A., Kerslake C. (2004) Turkish: A Comprehensive Grammar. London	https://www.omniglot.com/writing/turkish.htm
 Nganasan	Daria Demkina	Zhovnitskaja, S. N. (2009) Nganasanskij yazik. Krasnoyarsk	https://www.omniglot.com/writing/nganasan.htm
@@ -25,13 +25,13 @@ Pacoh	Daria Demkina	Watson R.,S., Canxóiq C. (2013) Pacoh – Vietnamese – En
 Kri	Daria Demkina	Enfield N. J., Diffloth G. (2009) Phonology and sketch grammar of Kri, a Vietic language of Laos. Cahiers de linguistique Asie orientale	http://omniglot.com/writing/kri.htm
 Wa	Daria Demkina	Mai M. S.(2012) A Descriptive Grammar of Wa. Payap University.	http://omniglot.com/writing/wa.htm
 Khmer	Daria Demkina	Gorgoniev Y. A. Grammatika khmerskogo jazyka [A grammar of the Khmer language] //Moskva: Izdatel’stvo Nauka. Decorative symmetry in ritual (and everyday) language. – 1966. – Т. 585.	NA
-Belorussian	Darya Zubova	Sjarzhuk, A. (2000) Govori so mnoj po-belorusski. Minsk	NA
-Bulgarian	Darya Zubova	Maslov, Yu. S. (1981) Grammatika bolgarskogo yazyka. Moscow	NA
+Belarusian 1	Darya Zubova	Sjarzhuk, A. (2000) Govori so mnoj po-belorusski. Minsk	NA
+Bulgarian 1	Darya Zubova	Maslov, Yu. S. (1981) Grammatika bolgarskogo yazyka. Moscow	NA
 Kazakh	Darya Zubova	Krippers, Karl A. (1997) Kazakh Grammar with Affix List	NA
 Kyrgyz	Darya Zubova	Kara, D. S. (2003) Kyrgyz, Lincom Europa	NA
 Tajik	Darya Zubova	Ido, Sh. (2005) Tajik, Lincom Europa	NA
 Uzbek	Darya Zubova	Ibragimov, S. I. (1972) Voprosy sovershenstvovaniya alfavitov tyurkskih yazykov SSSR, Moscow	NA
-Ukranian	Darya Zubova	Danyenko, A., Vakylenko, S. (1995) Ukranian, Lincom Europa, M_nchen-Newcastle	NA
+Ukrainian	Darya Zubova	Danyenko, A., Vakylenko, S. (1995) Ukranian, Lincom Europa, M_nchen-Newcastle	NA
 Serbian	Darya Zubova	Hammond, L. (2005) Serbian. An Essential Grammar. Routledge, London and New York	NA
 Macedonian	Darya Zubova	Friedman, V. (2001) Macedonian, SEELRC	NA
 Latvian	Darya Zubova	Mathiassen, T. (1996) A short grammar of Latvian, Slavica Publishers	NA
@@ -52,12 +52,12 @@ siSwati	Anna Simonyan	Corum, C. W. (1978). An Introduction to the Swazi (siSwati
 seTswana	Anna Simonyan	Peace Corps Botswana(2008). An Introduction to the Setswana Language	https://www.omniglot.com/writing/latin.htm
 chiTonga	Anna Simonyan	Carter, H., & Kashoki, M. E. (2002). An outline of Chitonga grammar. Bookworld Pub House.	https://www.omniglot.com/writing/latin.htm
 Tsonga	Anna Simonyan	Ouwehand, M. (1965). Everyday Tsonga. Swiss Mission in South Africa.	https://www.omniglot.com/writing/latin.htm
-Zulu	Anna Simonyan	Wilkes, A., & Nkosi, N. (2003). Zulu. Teach Yourself.	https://www.omniglot.com/writing/latin.htm
+Zulu 1	Anna Simonyan	Wilkes, A., & Nkosi, N. (2003). Zulu. Teach Yourself.	https://www.omniglot.com/writing/latin.htm
 Xhosa	Anna Simonyan	Kirsch, B., Skorge, S., & Magona, S. (2003). Teach Yourself Xhosa. Hodder Headline.	https://www.omniglot.com/writing/latin.htm
 Afrikaans	Anna Simonyan	McDermott, L. (2005). Teach Yourself Afrikaans. NTC Publishing Group.	https://www.omniglot.com/writing/latin.htm
-Belarusian	Violetta Ivanova	Peter Mayo. Belorussian. Bernard Comrie, Greville C. Corbett (eds.) The Slavonic Languages. London and New York, 1993.	http://www.omniglot.com/writing/belarusian.htm
+Belarusian 2	Violetta Ivanova	Peter Mayo. Belorussian. Bernard Comrie, Greville C. Corbett (eds.) The Slavonic Languages. London and New York, 1993.	http://www.omniglot.com/writing/belarusian.htm
 Ukrainian	Violetta Ivanova	Stefan M. Pugh and Ian Press. Ukrainian. A comprehensive grammar. 1999	https://www.omniglot.com/writing/ukrainian.htm
-Bulgarian	Violetta Ivanova	Ernest A. Scatton. Bulgarian. Bernard Comrie, Greville G. Corbett (eds.). The slavonic languages. 1993	https://www.omniglot.com/writing/bulgarian.htm
+Bulgarian 2	Violetta Ivanova	Ernest A. Scatton. Bulgarian. Bernard Comrie, Greville G. Corbett (eds.). The slavonic languages. 1993	https://www.omniglot.com/writing/bulgarian.htm
 Russian	Violetta Ivanova	Князев С.В., Пожарицкая С.К. Современный русский литературный язык. Фонетика, орфоэпия, графика и орфография. М.: Гаудеамус, 2011.	https://www.omniglot.com/writing/russian.htm
 Polish	Violetta Ivanova	Sadowska. Polish. A Comprehensive Grammar. Routledge: London and New York. 2012.	https://www.omniglot.com/writing/polish.htm
 Czech	Violetta Ivanova	Laura A. Janda and Charles E. Towsend. Czech. 2000	https://www.omniglot.com/writing/czech.htm
@@ -92,9 +92,9 @@ Tigrinya	Irina Astafyeva	Mason, J. S. (Ed.). (1996). Tigrinya grammar. Red Sea P
 Tigre Geez	Irina Astafyeva	Raz, S. (1983). Tigre grammar and texts (Vol. 4). Undena Publications.	http://www.omniglot.com/writing/tigre.htm
 Ainu Katakana	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	NA
 Ainu Latin	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	NA
-Aymar	Alina Tillabayeva	Hardman, Martha James, Juana Vásquez, and Juan de Dios Yapita. Aymara Grammatical Sketch: To Be Used with Aymar Ar Yatiqañataki. Gainesville, Fla: Aymara Language Materials Project, Dept. of Anthropology, University of Florida, 1971.	https://www.omniglot.com/writing/aymara.htm
+Aymara	Alina Tillabayeva	Hardman, Martha James, Juana Vásquez, and Juan de Dios Yapita. Aymara Grammatical Sketch: To Be Used with Aymar Ar Yatiqañataki. Gainesville, Fla: Aymara Language Materials Project, Dept. of Anthropology, University of Florida, 1971.	https://www.omniglot.com/writing/aymara.htm
 Paraguayan Guarani	Alina Tillabayeva	Estigarribia, B. (2017). A Grammar Sketch of Paraguayan Guarani. Guarani linguistics in the 21st century, 7-85.	https://www.omniglot.com/writing/guarani.htm
-Kichwa (Kichwa Shimi / Runa Shimi)	Alina Tillabayeva	"Натаров А. Н. (2013) Грамматика языка кечуа
+Kichwa	Alina Tillabayeva	"Натаров А. Н. (2013) Грамматика языка кечуа
 "	https://omniglot.com/writing/kichwa.htm
 Arawak	Alina Tillabayeva	Pet, W. (2011). A grammar sketch and lexicon of Arawak (Lokono Dian). SIL e-Books, 30.	https://www.omniglot.com/writing/arawak.htm
 Swahili	Asya Simonyan	Russell, J. (1996). Swahili (Teach Yourself).	
@@ -130,7 +130,7 @@ Dhivehi (Thaana)	Anna Sorokina	Gnanadesikan, A. E., (2012). Maldivian Thaana, Ja
 Welsh	Tanya Masumi	Awbery G. Welsh. – na, 2009.	https://www.omniglot.com/writing/welsh.htm
 Breton	Tanya Masumi	Press I., Bihan H. Colloquial Breton: The complete course for beginners //FORUM FOR MODERN LANGUAGE STUDIES. – GREAT CLARENDON ST, OXFORD OX2 6DP, ENGLAND : OXFORD UNIV PRESS, 2005.	https://www.omniglot.com/writing/breton.htm
 Cornish	Tanya Masumi	Smith A. S. D., Hooper E. G. R. Cornish simplified: short lessons for self-tuition: pronunciation, grammar, exercises. – Dyllansow Truran, 1972.	https://www.omniglot.com/writing/cornish.htm
-Scottish	Tanya Masumi	Gillies W. Scottish Gaelic //The Celtic Languages. – Routledge, 2009. – С. 244-318.	https://www.omniglot.com/writing/gaelic.htm
+Scottish Gaelic	Tanya Masumi	Gillies W. Scottish Gaelic //The Celtic Languages. – Routledge, 2009. – С. 244-318.	https://www.omniglot.com/writing/gaelic.htm
 Irish	Tanya Masumi	Doyle A. Irish, volume 201 of Languages of the World/Materials //Munich, Germany: LINCOM EUROPA. – 2001.	https://www.omniglot.com/writing/irish.htm
 Manx	Tanya Masumi	Broderick G. Manx //The Celtic Languages. – Routledge, 2009. – С. 319-370.	https://www.omniglot.com/writing/manx.htm
 Italian	Tanya Masumi	Sandro Carnevali, Fonetica della lingua italiana  (1998-2007)	https://www.omniglot.com/writing/italian.htm
@@ -152,7 +152,7 @@ German	Violetta Ivanova	Bruce Donaldson. German. An Essential Grammar. Routledge
 Dutch	Violetta Ivanova	Gerdi Quist, Dennis Strik. Teach Yourself Dutch. 2003	https://www.omniglot.com/writing/dutch.htm
 English (BrE)	Violetta Ivanova	Michael Swan. Practical English Usage. Oxford University Press, 2009	https://www.omniglot.com/writing/english.htm
 English (BrE)	Violetta Ivanova	Rebecca M. Dauer. Accurate English: a complete course in pronunciation. Prentice Hall Regents, 1993.	https://www.omniglot.com/writing/english.htm
-Idish	Violetta Ivanova	Dovid Katz. Grammar of the Yiddish Language. Duckworth, 1987.	https://www.omniglot.com/writing/yiddish.htm
+Yiddish	Violetta Ivanova	Dovid Katz. Grammar of the Yiddish Language. Duckworth, 1987.	https://www.omniglot.com/writing/yiddish.htm
 Finnish	Irina Astafyeva	https://www.scribd.com/doc/316881341/Teach-Yourself-Finnish-1-pdf#fullscreen=1	http://www.omniglot.com/writing/finnish.htm
 Moksha	Irina Astafyeva	Поляков О. Е. Русско-мокшанский разговорник //Саранск: Мордов. кн. изд-во. – 1993.	http://www.omniglot.com/writing/moksha.htm
 Ter Sami	Irina Astafyeva	Куруч Р. Д. Краткий грамматический очерк саамского языка //РД Куруч (ред.). Саамско-русский словарь. М: Русский язык. – 1985. – С. 529-567.	http://www.omniglot.com/writing/tersami.htm
@@ -161,7 +161,7 @@ Udmurt	Irina Astafyeva	"И. В. Тараканов. Алфавит. — Удму
 Nganasan	Irina Astafyeva	Жовницкая-Турдагина С. Н. Ня’’ букварь. СПб., 1999.	http://www.omniglot.com/writing/nganasan.htm
 Ingrian	Irina Astafyeva	http://lingvisto.org/files/ingrian.pdf	http://www.omniglot.com/writing/ingrian.htm
 Erzya	Irina Astafyeva	Г. Аитов. Новый алфавит. Великая революция на востоке. — Саратов: Нижневолжское краевое изд-во, 1932. — С. 61-64. — 73 с. — 3150 экз.	http://www.omniglot.com/writing/erzya.htm
-Voro (Uralic)	Irina Astafyeva	https://linguapedia.info/languages/voro.html	http://www.omniglot.com/writing/voro.htm
+Võro	Irina Astafyeva	https://linguapedia.info/languages/voro.html	http://www.omniglot.com/writing/voro.htm
 Northern Sami	Irina Astafyeva	Svonni, E Mikael. Sámegiel-ruoŧagiel skuvlasátnelistu. — Sámiskuvlastivra, 1984. — P. III.	http://www.omniglot.com/writing/northernsami.htm
 Skolt Sami	Irina Astafyeva	Korhonen, Mikko. Mosnikoff, Jouni. Sammallahti, Pekka. Koltansaamen opas. Castreanumin toimitteita, Helsinki 1973.	http://www.omniglot.com/writing/skoltsami.htm
 Karelian	Irina Astafyeva	Zajkov P. M. Grammatika karelĘąskogo jazyka:(fonetika i morfologija). – Periodika, 1999.	http://www.omniglot.com/writing/karelian.htm
@@ -174,7 +174,7 @@ Inuktitut	Roman Tarasov	Rogers (2005) Writing Systems: a Linguistic Approach. pp
 Bambara	Roman Tarasov	Doumboya (2012) Illustrated English/N'ko Alphabet: An Introduction to N'ko for English Speakers.	http://omniglot.com/writing/nko.htm
 Mongolian	Roman Tarasov	Bat-Ireedui (2015) Colloquial Mongolian. The Complete Course for Beginners	http://omniglot.com/writing/mongolian.htm
 Hanuno'o	Roman Tarasov	Conklin (1953) Hanunóo-English Vocabulary. Berkeley & Los-Angeles	http://omniglot.com/writing/hanunoo.htm
-Zulu	Roman Tarasov	Doke. Vilakazi (1972) Zulu-English Dictionary. Johannesburg	https://omniglot.com/writing/zulu.htm
+Zulu 2	Roman Tarasov	Doke. Vilakazi (1972) Zulu-English Dictionary. Johannesburg	https://omniglot.com/writing/zulu.htm
 Persian Braille	Roman Tarasov	UNESCO (2013) World Braille Usage. Washington,D.C.	https://omniglot.com/writing/braille.htm
 Itbayat	Nikita Shennikov	Cesar A. Hidalgo, A Tagmemic Grammar of Ivatan, 1971	
 Tao	Nikita Shennikov	Rau, D. Victoria, Maa-Neu Dong,  Yami texts with reference grammar and dictionary, 2006	

--- a/bibliography.csv
+++ b/bibliography.csv
@@ -1,207 +1,201 @@
-script	collected	source	omniglot
-Cherokee	Anna Verdieva	Montgomery-Anderson, 2008: 31-107	http://www.omniglot.com/writing/cherokee.htm
-Mkhedruli (Georgian)	Antonina Sinelnik	Aronson, Howard I. (1990). Georgian: a reading grammar	http://www.omniglot.com/writing/georgian2.htm
-Hangul (Korean)	Antonina Sinelnik	"Lee, Hyun Bok (1999). ""Korean"". Handbook of the International Phonetic Association"	http://www.omniglot.com/writing/korean.htm
-Armenian	Antonina Sinelnik	Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian	http://www.omniglot.com/writing/armenian.htm
-Amharic	Anna Verdieva	Leslau, W. (1995). Reference grammar of Amharic. Otto Harrassowitz Verlag.	http://www.omniglot.com/writing/amharic.htm
-Buryat	Vyacheslav Ivanov	Sanzheev (red.) (1962) Grammatica buryatskogo yazika: Fonetica i morfologiya / Red. G.D. Sanzheev. Moscow	http://www.omniglot.com/writing/cyrillic.htm
-Khakas	Vyacheslav Ivanov	Dyrenkova N. P. (1948) Grammatica khakasskogo yazika. Abakan	http://www.omniglot.com/writing/cyrillic.htm
-Tuvan	Vyacheslav Ivanov	Iskhakov, F. G., Palmbakh, A. A. (1961) Grammatica tuvinskogo yazika. Fonetica i morfologiya. Moscow	http://www.omniglot.com/writing/cyrillic.htm
-Yakut	Vyacheslav Ivanov	Kharitonov, L. N. (1947) Sovremennyj yakutskij yazyk: Fonetika i morfologiya. Yakutsk	http://www.omniglot.com/writing/cyrillic.htm
-Shor	Vyacheslav Ivanov	Dyrenkova N. P. (1941) Grammatika shorskogo yazyka. Moscow, Leningrad	http://www.omniglot.com/writing/cyrillic.htm
-Kalmyk	Vyacheslav Ivanov	Sanzheev G. D. (red.) Grammatika kalmytskogo yazyka. Fonetika i morfologiya. Elista	http://www.omniglot.com/writing/cyrillic.htm
-Bashkir	Vyacheslav Ivanov	Yuldashev, A. A. (red.) (1981) Grammatika sovremennogo bashkirskogo literaturnogo yazyka. Moscow	http://www.omniglot.com/writing/cyrillic.htm
-Tibetan	Anna Verdieva	Tournade N. (2003) Manual of Standard Tibetan +AC0- Language and Civilization/ Nicolas Tournade, Sangda Dorje +AC0- Ithaca, NY: Snow Lion Publications.	http://www.omniglot.com/writing/tibetan.htm
-Tamil	Anna Verdieva	Andronov, M. S. (1965). The Tamil Language. Nauka.	http://www.omniglot.com/writing/tamil.htm
-Mongolian (Cyrillic)	Vyacheslav Ivanov	Todaeva, B. Kh. (1951) Grammatika sovremennogo mongolskogo yazika. Moscow	http://www.omniglot.com/writing/mongolian.htm
-Japanese (Hiragana)	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-hiragana.htm
-Japanese (Katakana)	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese+AF8-katakana.htm
-Crimean Tatar	Vyacheslav Ivanov	Kavitskaya D. (2010) Crimean Tatar. Linkom Europa	https://www.omniglot.com/writing/crimeantatar.php
-Turkish	Vyacheslav Ivanov	Göksel A., Kerslake C. (2004) Turkish: A Comprehensive Grammar. London	https://www.omniglot.com/writing/turkish.htm
-Nganasan	Daria Demkina	Zhovnitskaja, S. N. (2009) Nganasanskij yazik. Krasnoyarsk	https://www.omniglot.com/writing/nganasan.htm
-Vietnamese	Daria Demkina	Thompson, L. C. (1987). A Vietnamese reference grammar (Vol. 13). University of Hawaii Press.	http://omniglot.com/writing/vietnamese.htm
-Nanai	Vyacheslav Ivanov	Avrorin, V. A. (1959) Grammatica nanajskogo jazyka. Moscow, Leningrad.	https://www.omniglot.com/writing/nanai.htm
-Pacoh	Daria Demkina	Watson R.,S., Canxóiq C. (2013) Pacoh – Vietnamese – English Dictionary. SIL International.	NA
-Kri	Daria Demkina	Enfield N. J., Diffloth G. (2009) Phonology and sketch grammar of Kri, a Vietic language of Laos. Cahiers de linguistique Asie orientale	http://omniglot.com/writing/kri.htm
-Wa	Daria Demkina	Mai M. S.(2012) A Descriptive Grammar of Wa. Payap University.	http://omniglot.com/writing/wa.htm
-Khmer	Daria Demkina	Gorgoniev Y. A. Grammatika khmerskogo jazyka [A grammar of the Khmer language] //Moskva: Izdatel’stvo Nauka. Decorative symmetry in ritual (and everyday) language. – 1966. – Т. 585.	NA
-Belarusian 1	Darya Zubova	Sjarzhuk, A. (2000) Govori so mnoj po-belorusski. Minsk	NA
-Bulgarian 1	Darya Zubova	Maslov, Yu. S. (1981) Grammatika bolgarskogo yazyka. Moscow	NA
-Kazakh	Darya Zubova	Krippers, Karl A. (1997) Kazakh Grammar with Affix List	NA
-Kyrgyz	Darya Zubova	Kara, D. S. (2003) Kyrgyz, Lincom Europa	NA
-Tajik	Darya Zubova	Ido, Sh. (2005) Tajik, Lincom Europa	NA
-Uzbek	Darya Zubova	Ibragimov, S. I. (1972) Voprosy sovershenstvovaniya alfavitov tyurkskih yazykov SSSR, Moscow	NA
-Ukrainian	Darya Zubova	Danyenko, A., Vakylenko, S. (1995) Ukranian, Lincom Europa, M_nchen-Newcastle	NA
-Serbian	Darya Zubova	Hammond, L. (2005) Serbian. An Essential Grammar. Routledge, London and New York	NA
-Macedonian	Darya Zubova	Friedman, V. (2001) Macedonian, SEELRC	NA
-Latvian	Darya Zubova	Mathiassen, T. (1996) A short grammar of Latvian, Slavica Publishers	NA
-Lithuanian	Darya Zubova	Mathiassen, T. (1996) A short grammar of Lithuanian, Slavica Publishers	NA
-Hän	Valeriia Kozenasheva	"Patrick E. Marlow ""Han phonology & morphology"" 1997."	https://www.omniglot.com/writing/han.htm
-Ahtna	Valeriia Kozenasheva	"Siri G. Tuttle ""Syllabic obstruents in Ahtna Athabaskan"" 2010"	https://www.omniglot.com/writing/ahtna.htm
-Apache	Valeriia Kozenasheva	"Harry Hoijer, ""Chiricahua Apache"" 1970."	https://www.omniglot.com/writing/apache.htm
-Beaver	Valeriia Kozenasheva	"Tiina Kathryn Randoja, ""The phonology and morphology og halfway river Beaver"", Ottawa, Canada, 1990."	https://www.omniglot.com/writing/beaver.htm
-Dena’ina	Valeriia Kozenasheva	Alan Boraas. (2009) An introduction to dena’ina grammar:  the kenai (outer inlet) dialect.	https://www.omniglot.com/writing/denaina.htm
-Eyak	Valeriia Kozenasheva	Michael E. Krauss (1965) Eyak: a preliminary report	https://www.omniglot.com/writing/eyak.php
-Hupa	Valeriia Kozenasheva	"Victor Karl Golla (1960) ""Hupa Grammar"""	https://www.omniglot.com/writing/hupa.htm
-Koyukon	Valeriia Kozenasheva	"Eliza Jones and Joe Kwaraceius (1997) ""Koyukon grammar"", August"	https://www.omniglot.com/writing/koyukon.htm
-Sarcee	Valeriia Kozenasheva	"Eung-Do Cook (1984) ""A Sarcee grammar"", Vancouver"	https://www.omniglot.com/writing/sarcee.htm
-Navajo	Valeriia Kozenasheva	"Irvy W. Goossen (1995) ""Dine Bizaad: Speak, Read, Write Navajo"""	https://www.omniglot.com/writing/navajo.htm
-Chipewyan	Valeriia Kozenasheva	Li Fang-Kuei	https://www.omniglot.com/writing/chipewyan.htm
-seSotho	Anna Simonyan	Paroz, R. A. (1946). Elements of Southern Sotho. Basutoland, Morija Sesuto Book Depot.	https://www.omniglot.com/writing/latin.htm
-siSwati	Anna Simonyan	Corum, C. W. (1978). An Introduction to the Swazi (siSwati) Language.	https://www.omniglot.com/writing/latin.htm
-seTswana	Anna Simonyan	Peace Corps Botswana(2008). An Introduction to the Setswana Language	https://www.omniglot.com/writing/latin.htm
-chiTonga	Anna Simonyan	Carter, H., & Kashoki, M. E. (2002). An outline of Chitonga grammar. Bookworld Pub House.	https://www.omniglot.com/writing/latin.htm
-Tsonga	Anna Simonyan	Ouwehand, M. (1965). Everyday Tsonga. Swiss Mission in South Africa.	https://www.omniglot.com/writing/latin.htm
-Zulu 1	Anna Simonyan	Wilkes, A., & Nkosi, N. (2003). Zulu. Teach Yourself.	https://www.omniglot.com/writing/latin.htm
-Xhosa	Anna Simonyan	Kirsch, B., Skorge, S., & Magona, S. (2003). Teach Yourself Xhosa. Hodder Headline.	https://www.omniglot.com/writing/latin.htm
-Afrikaans	Anna Simonyan	McDermott, L. (2005). Teach Yourself Afrikaans. NTC Publishing Group.	https://www.omniglot.com/writing/latin.htm
-Belarusian 2	Violetta Ivanova	Peter Mayo. Belorussian. Bernard Comrie, Greville C. Corbett (eds.) The Slavonic Languages. London and New York, 1993.	http://www.omniglot.com/writing/belarusian.htm
-Ukrainian	Violetta Ivanova	Stefan M. Pugh and Ian Press. Ukrainian. A comprehensive grammar. 1999	https://www.omniglot.com/writing/ukrainian.htm
-Bulgarian 2	Violetta Ivanova	Ernest A. Scatton. Bulgarian. Bernard Comrie, Greville G. Corbett (eds.). The slavonic languages. 1993	https://www.omniglot.com/writing/bulgarian.htm
-Russian	Violetta Ivanova	Князев С.В., Пожарицкая С.К. Современный русский литературный язык. Фонетика, орфоэпия, графика и орфография. М.: Гаудеамус, 2011.	https://www.omniglot.com/writing/russian.htm
-Polish	Violetta Ivanova	Sadowska. Polish. A Comprehensive Grammar. Routledge: London and New York. 2012.	https://www.omniglot.com/writing/polish.htm
-Czech	Violetta Ivanova	Laura A. Janda and Charles E. Towsend. Czech. 2000	https://www.omniglot.com/writing/czech.htm
-Slovenian	Violetta Ivanova	Peter Herrity. Slovene. A comprehensive grammar. Routledge. 2000	https://www.omniglot.com/writing/slovene.htm
-Slovak	Violetta Ivanova	David Short. Slovak. In Bernard Comrie, Creville C. Corbett (eds). The Slavonic Languages. London and New York, Routledge. 1993	https://www.omniglot.com/writing/slovak.htm
-Upper Sorbian	Violetta Ivanova	Gerald Stone. Sorbian (Upper and Lower). In Bernard Comrie, Creville C. Corbett (eds). The Slavonic Languages. London and New York, Routledge. 2095	https://www.omniglot.com/writing/sorbian.htm
-Lower Sorbian	Violetta Ivanova	Gerald Stone. Sorbian (Upper and Lower). In Bernard Comrie, Creville C. Corbett (eds). The Slavonic Languages. London and New York, Routledge. 2095	https://www.omniglot.com/writing/sorbian.htm
-Persian	Tanya Masumi	Perry J. R., Windfuhr G. Persian and Tajik //The Iranian Languages. – Routledge, 2013. – С. 492-620	https://www.omniglot.com/writing/persian.htm
-Tadjik	Tanya Masumi	Perry J. R., Windfuhr G. Persian and Tajik //The Iranian Languages. – Routledge, 2013. – С. 492-620	https://www.omniglot.com/writing/tajik.htm
-Maori	Tanya Masumi	Williams W. L. First lessons in the Maori language with a short vocabulary.-- Trübner & Company, 1862.	https://www.omniglot.com/writing/maori.htm
-Yapese	Tanya Masumi	Phillips L. // Yapese Alphabet.-- Pacific Resources for Education and Learning, 2006	https://www.omniglot.com/writing/yapese.htm
-Samoan	Tanya Masumi	Neffgen H. Grammar and Vocabulary of the Samoan Language, Together with Remarks on Some of the Points of Similarity Between the Samoan and the Tahitian and Maori Languages. – Ams PressInc, 1978. – Т. 30.	https://www.omniglot.com/writing/samoan.htm
-Tahitian	Tanya Masumi	Burbidge G. W. A new grammar of the Tahitian dialect of the Polynesian language: And combined with a vocabulary of English, French, Tahitian //Papeete, Tahiti, French Polynesia, Church of Jesus Christ of Latter-Day Saints. – 1930.	https://www.omniglot.com/writing/tahitian.htm
-Niuean	Tanya Masumi	Tregear E., Smith S. P. Vocabulary and grammar of the Niué dialect of the Polynesian language. – J. Mackay, Government Printer, 1907	https://www.omniglot.com/writing/niuean.php
-Fijian	Tanya Masumi	Dixon R. M. W. A grammar of Boumaa Fijian. – University of Chicago Press, 1988.	https://www.omniglot.com/writing/fijian.htm
-Futunan	Tanya Masumi	Diessel H. Demonstratives: Form, function and grammaticalization. – John Benjamins Publishing, 1999. – Т. 42.	https://www.omniglot.com/writing/futunan.htm
-Hebrew	Irina Astafyeva	Glinert, L. (2004). The grammar of modern Hebrew. Cambridge University Press.	http://www.omniglot.com/writing/hebrew.htm
-Syriac	Irina Astafyeva	Muraoka, T. (2005). Classical Syriac: a basic grammar with a chrestomathy (Vol. 19). Otto Harrassowitz Verlag.	http://www.omniglot.com/writing/syriac.htm
-Dari	Irina Astafyeva	Wahab, S. (2004). Beginner's Dari (Persian). Hippocrene Books.	http://www.omniglot.com/writing/dari.htm
-Pashto	Irina Astafyeva	Lehr, R. (2014). A descriptive grammar of Pashai: The language and speech community of Darrai Nur. The University of Chicago.	http://www.omniglot.com/writing/pashto.htm
-Persian	Irina Astafyeva	Perry, J. R., & Windfuhr, G. (2013). Persian and Tajik. In The Iranian Languages (pp. 492-620). Routledge.	http://www.omniglot.com/writing/persian.htm
-Arabic	Irina Astafyeva	Ryding, K. C. (2005). Modern Standard Arabic. Cambridge University Pres, UK.	http://www.omniglot.com/writing/arabic.htm
-Acehnese	Irina Astafyeva	Durie, M. (1987). Grammatical relations in Acehnese. Studies in Language. International Journal sponsored by the Foundation “Foundations of Language”, 11(2), 365-399.	http://www.omniglot.com/writing/acehnese.htm
-Sorani	Irina Astafyeva	Thackston, W. M. (2006). Kurmanji Kurdish:-A Reference Grammar with Selected Readings. Renas Media.	http://www.omniglot.com/writing/kurdish.htm
-Kurdish	Irina Astafyeva	McCarus, E. N. (2013). Kurdish. In The Iranian Languages (pp. 663-709). Routledge.	http://www.omniglot.com/writing/kurdish.htm
-Somali Abjad	Irina Astafyeva	Saeed, J. (1999). Somali (Vol. 10). John Benjamins Publishing.	http://www.omniglot.com/writing/somali.htm
-Somali Latin	Irina Astafyeva	Saeed, J. (1999). Somali (Vol. 10). John Benjamins Publishing.	http://www.omniglot.com/writing/somali.htm
-Urdu	Irina Astafyeva	Delacy, R. (2003). Teach Yourself Beginner's Urdu Script. Teach Yourself.	http://www.omniglot.com/writing/urdu.htm
-Comorian	Irina Astafyeva	Mohamed, M. A. (2001). Modern Swahili Grammar. East African Publishers.	http://www.omniglot.com/writing/comorian.htm
-Tigre Abjad	Irina Astafyeva	Raz, S. (1983). Tigre grammar and texts (Vol. 4). Undena Publications.	http://www.omniglot.com/writing/tigre.htm
-Tigrinya	Irina Astafyeva	Mason, J. S. (Ed.). (1996). Tigrinya grammar. Red Sea Press (NJ).	http://www.omniglot.com/writing/tigrinya.htm
-Tigre Geez	Irina Astafyeva	Raz, S. (1983). Tigre grammar and texts (Vol. 4). Undena Publications.	http://www.omniglot.com/writing/tigre.htm
-Ainu Katakana	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	NA
-Ainu Latin	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	NA
-Aymara	Alina Tillabayeva	Hardman, Martha James, Juana Vásquez, and Juan de Dios Yapita. Aymara Grammatical Sketch: To Be Used with Aymar Ar Yatiqañataki. Gainesville, Fla: Aymara Language Materials Project, Dept. of Anthropology, University of Florida, 1971.	https://www.omniglot.com/writing/aymara.htm
-Paraguayan Guarani	Alina Tillabayeva	Estigarribia, B. (2017). A Grammar Sketch of Paraguayan Guarani. Guarani linguistics in the 21st century, 7-85.	https://www.omniglot.com/writing/guarani.htm
-Kichwa	Alina Tillabayeva	"Натаров А. Н. (2013) Грамматика языка кечуа
-"	https://omniglot.com/writing/kichwa.htm
-Arawak	Alina Tillabayeva	Pet, W. (2011). A grammar sketch and lexicon of Arawak (Lokono Dian). SIL e-Books, 30.	https://www.omniglot.com/writing/arawak.htm
-Swahili	Asya Simonyan	Russell, J. (1996). Swahili (Teach Yourself).	
-Kikuyu	Asya Simonyan	Gecaga, B. M., & Kirkaldy-Willis, W. H. (1953). Short Kikuyu Grammar. Macmillan Kenya.	
-Kwanyama	Asya Simonyan	Zimmermann, W., & Hasheela, P. (1998). Oshikwanyama grammar. Gamsberg Macmillan Publishers (Pty) Ltd..	
-Lingala	Asya Simonyan	"Redden, J. & Bongo, F. (1963). Lingala, basic course. Washington:
-Department of State"	
-Fula	Asya Simonyan	Pelletier, C. A., & Skinner, A. N. (1981). Adawama Fulfulde. An introductory course. African Languages and Literature University of Wisconsin-Madison	
-Temne	Asya Simonyan	Peace Corps Sierra Leone (1987). Temne Language Manual.	
-Wolof	Asya Simonyan	Peace Corps The Gambia (1995). Wollof Grammar Manual.	
-Ewe	Asya Simonyan	Warburton, I. (1968). Ewe basic course.	
-Abaza	Anna Sorokina	Hewitt, G. (2004). Introduction to the Study of the Languages of the Caucasus. München: Lincom.	https://www.omniglot.com/writing/abaza.htm
-Abkhaz	Anna Sorokina	Hewitt, G. (2004). Introduction to the Study of the Languages of the Caucasus. München: Lincom.	https://www.omniglot.com/writing/abkhaz.htm
-Adyghe	Anna Sorokina	Hewitt, G. (2005). North West Caucasian. Lingua, 115(1–2), 91–145.	https://www.omniglot.com/writing/adyghe.htm
-Kabardian	Anna Sorokina	Matasović, R. (2010). A short grammar of East Circassian (Kabardian).	https://www.omniglot.com/writing/kabardian.htm
-Aghul	Anna Sorokina	Магометов, А. А. (1967). Агульский язык. Языки народов СССР, Т.4: Кавказские языки. Москва, 562-579.	https://www.omniglot.com/writing/aghul.htm
-Aghul	Anna Sorokina	Гасанова, С.Н. (2016) Говорим по-агульски.  Махачкала: Издательство ДГУ.	https://www.omniglot.com/writing/aghul.htm
-Archi	Anna Sorokina	Chumakina, M., Brown, D., Corbett, G., Quilliam, H. (2007). A dictionary of Archi: Archi-Russian-English (Online edition). University of Surrey. 	httpsː//www.omniglot.com/writing/archi.htm
-Avar	Anna Sorokina	Мадиева, Г. И. (1967) Аварский язык. Языки народов СССР, Т.4: Кавказские языки. Москва, 255-271.	http://www.omniglot.com/writing/avar.htm
-Chechen	Anna Sorokina	Dotton, Z., Wagner, J. D. A grammar of Chechen.	https://www.omniglot.com/writing/chechen.htm
-Dargwa	Anna Sorokina	Абдуллаев, С.Н. (1954). Грамматика даргинского языка (фонетика и морфология). Махачкала: Институт истории, языка и литературы Дагестанского филиала АН СССР.	https://www.omniglot.com/writing/dargwa.htm
-Lak	Anna Sorokina	Schulze, W. (2007). The Lak Language — Лакку маз. A Quick Reference.	https://www.omniglot.com/writing/lak.htm
-Lezgi	Anna Sorokina	Haspelmath, M. (1993). A grammar of Lezgian. Berlin; New York: Mouton de Gruyter.	https://www.omniglot.com/writing/lezgi.htm
-Tabasaran	Anna Sorokina	Алексеев, М.Е., Шихалиева, С.Х. (2003). Табасаранский язык. Языки народов России. Москва: Academia.	httpsː//www.omniglot.com/writing/tabassaran.htm
-Bengali	Anna Sorokina	Thompson, H.-R. (2012). Bengali. Amsterdam: John Benjamins Pub. Co.	https://www.omniglot.com/writing/bengali.htm
-Hindi (Devanāgarī)	Anna Sorokina	Kachru, Y. (2006). Hindi. Philadelphia: John Benjamins Pub. Co.	https://www.omniglot.com/writing/hindi.htm
-Kannada	Anna Sorokina	Spencer, H., & Perston, W. (1950). A Kanarese grammar: With graduated exercises. Mysore City, India: Wesley Press.	https://www.omniglot.com/writing/kannada.htm
-Malayalam	Anna Sorokina	Asher, R. E., & Kumari, T. C. (1997). Malayalam.	https://www.omniglot.com/writing/malayalam.htm
-Sinhala	Anna Sorokina	Chandralal, D. (2010). Sinhala. Amsterdam: John Benjamins Pub. Co.	https://www.omniglot.com/writing/sinhala.htm
-Telugu	Anna Sorokina	Krishnamurti, B., & Gwynn, J. P. L. (1985). A grammar of modern Telugu. Delhi: Oxford University Press.	https://www.omniglot.com/writing/telugu.htm
-Panjabi (Gurmukhi)	Anna Sorokina	Bhardwaj, M. (2012). Colloquial Panjabi. London: Routledge.	https://www.omniglot.com/writing/punjabi.htm
-Dhivehi (Thaana)	Anna Sorokina	Gnanadesikan, A. E., (2012). Maldivian Thaana, Japanese kana, and the representation of moras in writing, Writing Systems Research, 4:1, 91-102, DOI: 10.1080/17586801.2012.693459	https://www.omniglot.com/writing/thaana.htm
-Welsh	Tanya Masumi	Awbery G. Welsh. – na, 2009.	https://www.omniglot.com/writing/welsh.htm
-Breton	Tanya Masumi	Press I., Bihan H. Colloquial Breton: The complete course for beginners //FORUM FOR MODERN LANGUAGE STUDIES. – GREAT CLARENDON ST, OXFORD OX2 6DP, ENGLAND : OXFORD UNIV PRESS, 2005.	https://www.omniglot.com/writing/breton.htm
-Cornish	Tanya Masumi	Smith A. S. D., Hooper E. G. R. Cornish simplified: short lessons for self-tuition: pronunciation, grammar, exercises. – Dyllansow Truran, 1972.	https://www.omniglot.com/writing/cornish.htm
-Scottish Gaelic	Tanya Masumi	Gillies W. Scottish Gaelic //The Celtic Languages. – Routledge, 2009. – С. 244-318.	https://www.omniglot.com/writing/gaelic.htm
-Irish	Tanya Masumi	Doyle A. Irish, volume 201 of Languages of the World/Materials //Munich, Germany: LINCOM EUROPA. – 2001.	https://www.omniglot.com/writing/irish.htm
-Manx	Tanya Masumi	Broderick G. Manx //The Celtic Languages. – Routledge, 2009. – С. 319-370.	https://www.omniglot.com/writing/manx.htm
-Italian	Tanya Masumi	Sandro Carnevali, Fonetica della lingua italiana  (1998-2007)	https://www.omniglot.com/writing/italian.htm
-Spanish	Tanya Masumi	Garrido, J. M., Machuca, M. J. y de la Mota, C. (1998). Prácticas de fonética. Lengua española I. Bellaterra: Universitat Autònoma de Barcelona.	https://www.omniglot.com/writing/spanish.htm
-Moldovan	Tanya Masumi	Краткая энциклопедия «Советская Молдавия» (Кишинёв, 1982)	https://www.omniglot.com/writing/moldovan.htm
-Portuguese	Tanya Masumi	"Izabel Christine Seara, Vanessa Gonzaga, Cristiane Lazzarotto-Volcão. Fonética e Fonologia do Português Brasileiro - Florianópolis, 2011
-"	https://www.omniglot.com/writing/portuguese.htm
-Romansch	Tanya Masumi	Caduff R., Caprez U. N., Darms G. Grammatica d'instrucziun dal rumantsch grischun. – Department da linguatgs e litteraturas romanas, 2006.	https://www.omniglot.com/writing/romansh.htm
-Romanian	Tanya Masumi	Cojocaru D. Romanian grammar. – Slavic and East European Language Research Center (SEELRC), Duke University, 2003.	https://www.omniglot.com/writing/romanian.htm
-Catalan	Tanya Masumi	Miyara Alberto José, Brunelli Mihele. Catalan Grammar / Грамматика каталанского языка	https://www.omniglot.com/writing/catalan.htm
-French	Tanya Masumi	Batchelor R. E., Chebli-Saadi M. A reference grammar of French. – Cambridge University Press, 2011.	https://www.omniglot.com/writing/french.htm
-Icelandic	Violetta Ivanova	Höskuldur Thráinsson. Icelandic. In Konig, E., & Van der Auwera, J. (2013). The germanic languages. Routledge.	https://www.omniglot.com/writing/icelandic.htm
-Icelandic	Violetta Ivanova	Hildur Jonsdottir. Teach yourself Icelandic. McGraw-Hill, 2004.	https://www.omniglot.com/writing/icelandic.htm
-Faroese	Violetta Ivanova	Hjalmar P. Petersen and Jonathan Adams. Faroese. A Language Course for Beginners. Grammar. Stidin, 2009.	https://www.omniglot.com/writing/faroese.htm
-Danish	Violetta Ivanova	Michael Herslund. Danish. Lincom Europa, 2002.	https://www.omniglot.com/writing/danish.htm
-Norwegian	Violetta Ivanova	Margaretha Danbolt Simons. Teach Yourself Norwegian. 2004.	https://www.omniglot.com/writing/norwegian.htm
-Swedish	Violetta Ivanova	Vera Croghan. Swedish (Teach Yourself). 1995.	https://www.omniglot.com/writing/swedish.htm
-German	Violetta Ivanova	Bruce Donaldson. German. An Essential Grammar. Routledge: London and New York, 2007.	https://www.omniglot.com/writing/german.htm
-Dutch	Violetta Ivanova	Gerdi Quist, Dennis Strik. Teach Yourself Dutch. 2003	https://www.omniglot.com/writing/dutch.htm
-English (BrE)	Violetta Ivanova	Michael Swan. Practical English Usage. Oxford University Press, 2009	https://www.omniglot.com/writing/english.htm
-English (BrE)	Violetta Ivanova	Rebecca M. Dauer. Accurate English: a complete course in pronunciation. Prentice Hall Regents, 1993.	https://www.omniglot.com/writing/english.htm
-Yiddish	Violetta Ivanova	Dovid Katz. Grammar of the Yiddish Language. Duckworth, 1987.	https://www.omniglot.com/writing/yiddish.htm
-Finnish	Irina Astafyeva	https://www.scribd.com/doc/316881341/Teach-Yourself-Finnish-1-pdf#fullscreen=1	http://www.omniglot.com/writing/finnish.htm
-Moksha	Irina Astafyeva	Поляков О. Е. Русско-мокшанский разговорник //Саранск: Мордов. кн. изд-во. – 1993.	http://www.omniglot.com/writing/moksha.htm
-Ter Sami	Irina Astafyeva	Куруч Р. Д. Краткий грамматический очерк саамского языка //РД Куруч (ред.). Саамско-русский словарь. М: Русский язык. – 1985. – С. 529-567.	http://www.omniglot.com/writing/tersami.htm
-Enets	Irina Astafyeva	Siegl F. Materials on Forest Enets, an indigenous language of Northern Siberia : дис. – 2011.	http://www.omniglot.com/writing/enets.htm
-Udmurt	Irina Astafyeva	"И. В. Тараканов. Алфавит. — Удмуртская Республика: Энциклопедия. — Ижевск : ""Удмуртия"", 2000. — С. 168. — 800 с."	http://www.omniglot.com/writing/udmurt.htm
-Nganasan	Irina Astafyeva	Жовницкая-Турдагина С. Н. Ня’’ букварь. СПб., 1999.	http://www.omniglot.com/writing/nganasan.htm
-Ingrian	Irina Astafyeva	http://lingvisto.org/files/ingrian.pdf	http://www.omniglot.com/writing/ingrian.htm
-Erzya	Irina Astafyeva	Г. Аитов. Новый алфавит. Великая революция на востоке. — Саратов: Нижневолжское краевое изд-во, 1932. — С. 61-64. — 73 с. — 3150 экз.	http://www.omniglot.com/writing/erzya.htm
-Võro	Irina Astafyeva	https://linguapedia.info/languages/voro.html	http://www.omniglot.com/writing/voro.htm
-Northern Sami	Irina Astafyeva	Svonni, E Mikael. Sámegiel-ruoŧagiel skuvlasátnelistu. — Sámiskuvlastivra, 1984. — P. III.	http://www.omniglot.com/writing/northernsami.htm
-Skolt Sami	Irina Astafyeva	Korhonen, Mikko. Mosnikoff, Jouni. Sammallahti, Pekka. Koltansaamen opas. Castreanumin toimitteita, Helsinki 1973.	http://www.omniglot.com/writing/skoltsami.htm
-Karelian	Irina Astafyeva	Zajkov P. M. Grammatika karelĘąskogo jazyka:(fonetika i morfologija). – Periodika, 1999.	http://www.omniglot.com/writing/karelian.htm
-Hungarian	Irina Astafyeva	Törkenczy M. Hungarian verbs and essentials of grammar: a practical guide to the mastery of Hungarian. – Ntc Pub Group, 1997.	http://www.omniglot.com/writing/hungarian.htm
-Estonian	Irina Astafyeva	http://www.eki.ee/knn/ungegn/un7_gdl.htm	http://www.omniglot.com/writing/estonian.htm
-Southern Sami	Irina Astafyeva	Vangberg – Brandsfjell: Saemesth amma! Gïelemaahtotje - Liten grammatikk. Sijti Jarnge 2009.	http://www.omniglot.com/writing/southernsami.htm
-Komi-Permyak	Irina Astafyeva	Лыткин В. И. (ред. ) Коми-пермяцкий язык. Введение, фонетика, лексика и морфология. Кудымкар: Коми-пермяцкое книжное издательство, 1962. - 340 с.	http://www.omniglot.com/writing/oldpermic.htm
-Nivkh	Roman Tarasov	Gashilova (2002) Nivkhskij yazik v tablitsax. Saint-Petersburg	http://omniglot.com/writing/nivkh.htm
-Inuktitut	Roman Tarasov	Rogers (2005) Writing Systems: a Linguistic Approach. pp.253-254	http://omniglot.com/writing/inuktitut.htm
-Bambara	Roman Tarasov	Doumboya (2012) Illustrated English/N'ko Alphabet: An Introduction to N'ko for English Speakers.	http://omniglot.com/writing/nko.htm
-Mongolian	Roman Tarasov	Bat-Ireedui (2015) Colloquial Mongolian. The Complete Course for Beginners	http://omniglot.com/writing/mongolian.htm
-Hanuno'o	Roman Tarasov	Conklin (1953) Hanunóo-English Vocabulary. Berkeley & Los-Angeles	http://omniglot.com/writing/hanunoo.htm
-Zulu 2	Roman Tarasov	Doke. Vilakazi (1972) Zulu-English Dictionary. Johannesburg	https://omniglot.com/writing/zulu.htm
-Persian Braille	Roman Tarasov	UNESCO (2013) World Braille Usage. Washington,D.C.	https://omniglot.com/writing/braille.htm
-Itbayat	Nikita Shennikov	Cesar A. Hidalgo, A Tagmemic Grammar of Ivatan, 1971	
-Tao	Nikita Shennikov	Rau, D. Victoria, Maa-Neu Dong,  Yami texts with reference grammar and dictionary, 2006	
-N'Ko	Nikita Shennikov	The History of N’ko and its Role in Mande Transnational Identity: Words as Weapons, 2005	
-Igbo	Nikita Shennikov	Fichman, B. S. (1975). Jazyk igbo. Izdat. Nauka.	
-Yoruba	Nikita Shennikov	Ọladele A. 1978 Essentials of Yoruba grammar	
-Vai	Nikita Shennikov	S. Lamii Tucker, 1999	
-Wallisian	Nikita Shennikov	Tsukamoto Akihisa, The language of Niuafo'ou Island, 1988	
-Vaeakau-Taumako	Nikita Shennikov	Næss A., Hovdhaugen E, A grammar of Vaeakau-Taumako, 2011	
-Tuvaluan	Nikita Shennikov	Niko Besnier, Tuvaluan: A Polynesian Language of the Central Pacific, 2000	
-Tokelauan	Nikita Shennikov	Hooper Robin, Studies in Tokelauan syntax, 1994	
-Tikopia	Nikita Shennikov	Firth Raymond, Tikopia-English Dictionary, 1985	
-Sikaiana	Nikita Shennikov	Donner W.,  LINGUA FRANCA AND VERNACULAR: LANGUAGE USE AND LANGUAGE CHANGE ON SIKAIANA, 1996	
-Rennellese	Nikita Shennikov	Samuel H. Elbert, Dictionary of the Language of Rennell and Bellona, 1975	
-Rarotongan	Nikita Shennikov	Maki'uti Tongia, Learning Rarotonga Maori, 1999	
-Pukapukan	Nikita Shennikov	Teingo W. A., Introduction to the Pukapukan Language, 1993	
-Niuafo'ou	Nikita Shennikov	Akihisa Tsukamoto, The language of Niuafo'ou Island, 1988	https://www.omniglot.com/writing/niuafoou.htm
-Kapingamarangi	Nikita Shennikov	Elbert S. , Kapingamarangi and Nukuoro Word List, With Notes on Linguistic Position, 1946 Pronunciation, and Grammar.	https://www.omniglot.com/writing/kapingamarangi.htm
-Hawaiian	Nikita Shennikov	Elbert S.H., Pukui M.K., Hawaiian Grammar, 1979	
-Anutan	Nikita Shennikov	Feinberg Richard, The Anutan Language Reconsidered: Lexicon and Grammar of a Polynesian Outlier, Volume 1, 1977	https://www.omniglot.com/writing/anutan.htm
-Vananga rapa nui	Nikita Shennikov	Paulus-Jan Kieviet, A grammar of Rapa Nui, 2017	https://www.omniglot.com/writing/rapanui.htm
-Moriori	Nikita Shennikov	Herbert William Williams, Some Notes on the Language of the Chatham Islands, 1918	https://www.omniglot.com/writing/moriori.htm
-Mele-Fila	Nikita Shennikov	Ross Clark, Mele Notes, 1975	https://www.omniglot.com/writing/mele-fila.htm
-Mangareva	Nikita Shennikov	Ena Manuireva, Mangarevan - A Shifting Language, 2014	https://www.omniglot.com/writing/mangareva.htm
-Faka-Tongan	Nikita Shennikov	C. Maxwell Churchward, Tongan Grammar, 1985	https://www.omniglot.com/writing/tongan.htm
-Nukuoro	Nikita Shennikov	Vern Carroll, An Outline of the Structure of the Language of Nukuoro, 1965	https://www.omniglot.com/writing/nukuoro.htm
-Rutul Cyrillic	Arseniy Averin	Clarkson J., Iurkova E. Important Factors in the Development of an Orthography: Shin-Shorsu Rutul — a Case Study. Dallas, SIL International, 2015	http://www.omniglot.com/writing/rutul.htm
-Rutul Latin	Arseniy Averin	Clarkson J., Iurkova E. Important Factors in the Development of an Orthography: Shin-Shorsu Rutul — a Case Study. Dallas, SIL International, 2015	
-Ingush	Arseniy Averin	Nichols J. Ingush Grammar. University of California, Berkeley. 2011	http://www.omniglot.com/writing/ingush.htm
-Ndyuka Latin	Arseniy Averin	Hutter G.L., Hutter M.L. Ndyuka. Routledge. 1994	http://www.omniglot.com/writing/ndjuka.htm
+script	glottocode	collected	source	omniglot	iso15924
+Abaza	abaz1241	Anna Sorokina	Hewitt, G. (2004). Introduction to the Study of the Languages of the Caucasus. München: Lincom.	https://www.omniglot.com/writing/abaza.htm	Cyrl
+Abkhaz	abkh1244	Anna Sorokina	Hewitt, G. (2004). Introduction to the Study of the Languages of the Caucasus. München: Lincom.	https://www.omniglot.com/writing/abkhaz.htm	Cyrl
+Acehnese	achi1257	Irina Astafyeva	Durie, M. (1987). Grammatical relations in Acehnese. Studies in Language. International Journal sponsored by the Foundation: Foundations of Language, 11(2), 365-399.	https://www.omniglot.com/writing/acehnese.htm	Latn
+Adyghe	adyg1241	Anna Sorokina	Hewitt, G. (2005). North West Caucasian. Lingua, 115(1–2), 91–145.	https://www.omniglot.com/writing/adyghe.htm	Cyrl
+Afrikaans	afri1274	Anna Simonyan	McDermott, L. (2005). Teach Yourself Afrikaans. NTC Publishing Group.	https://www.omniglot.com/writing/afrikaans.htm	Latn
+Aghul	aghu1253	Anna Sorokina	Магометов, А. А. (1967). Агульский язык. Языки народов СССР, Т.4: Кавказские языки. Москва, 562-579. Гасанова, С.Н. (2016) Говорим по-агульски.  Махачкала: Издательство ДГУ.	https://www.omniglot.com/writing/aghul.htm	Cyrl
+Ahtna	ahte1237	Valeriia Kozenasheva	Siri G. Tuttle. 2010. Syllabic obstruents in Ahtna Athabaskan.	https://www.omniglot.com/writing/ahtna.htm	Latn
+Ainu (Katakana)	ainu1252	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	https://www.omniglot.com/writing/ainu.htm	Kana
+Ainu (Latin)	ainu1252	Kanami Tobe	1994『アコㇿ イタㇰAKOR ITAK アイヌ語テキスト１』, Phonplogical change in Japanese-Ainu Loanwords, Edwin Everhart, 2009: 10-11	https://www.omniglot.com/writing/ainu.htm	Latn
+Amharic	amha1245	Anna Verdieva	Leslau, W. (1995). Reference grammar of Amharic. Otto Harrassowitz Verlag.	https://www.omniglot.com/writing/amharic.htm	Ethi
+Anutan	anut1237	Nikita Shennikov	Feinberg Richard, The Anutan Language Reconsidered: Lexicon and Grammar of a Polynesian Outlier, Volume 1, 1977	https://www.omniglot.com/writing/anutan.htm	Latn
+Apache	west2615	Valeriia Kozenasheva	Harry Hoijer. 1970. Chiricahua Apache.	https://www.omniglot.com/writing/apache.htm	Latn
+Arabic	arab1395	Irina Astafyeva	Ryding, K. C. (2005). Modern Standard Arabic. Cambridge University Pres, UK.	https://www.omniglot.com/writing/arabic.htm	Arab
+Arawak	araw1281	Alina Tillabayeva	Pet, W. (2011). A grammar sketch and lexicon of Arawak (Lokono Dian). SIL e-Books, 30.	https://www.omniglot.com/writing/arawak.htm	Latn
+Archi	arch1244	Anna Sorokina	Chumakina, M., Brown, D., Corbett, G., Quilliam, H. (2007). A dictionary of Archi: Archi-Russian-English (Online edition). University of Surrey.	https://www.omniglot.com/writing/archi.htm	Cyrl
+Armenian	nucl1235	Antonina Sinelnik	Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian	https://www.omniglot.com/writing/armenian.htm	Armn
+Avar	avar1256	Anna Sorokina	Мадиева, Г. И. (1967) Аварский язык. Языки народов СССР, Т.4: Кавказские языки. Москва, 255-271.	https://www.omniglot.com/writing/avar.htm	Cyrl
+Aymara	nucl1667	Alina Tillabayeva	Hardman, Martha James, Juana Vásquez, and Juan de Dios Yapita. Aymara Grammatical Sketch: To Be Used with Aymar Ar Yatiqañataki. Gainesville, Fla: Aymara Language Materials Project, Dept. of Anthropology, University of Florida, 1971.	https://www.omniglot.com/writing/aymara.htm	Latn
+Bambara	bamb1269	Roman Tarasov	Doumboya (2012) Illustrated English/N'ko Alphabet: An Introduction to N'ko for English Speakers.	https://omniglot.com/writing/nko.htm	Nkoo
+Bashkir	bash1264	Vyacheslav Ivanov	Yuldashev, A. A. (red.) (1981) Grammatika sovremennogo bashkirskogo literaturnogo yazyka. Moscow	https://www.omniglot.com/writing/bashkir.htm	Cyrl
+Beaver	beav1236	Valeriia Kozenasheva	Tiina Kathryn Randoja. 1990. The phonology and morphology of halfway river Beaver. Ottawa, Canada.	https://www.omniglot.com/writing/beaver.htm	Latn
+Belarusian 1	bela1254	Darya Zubova	Sjarzhuk, A. (2000) Govori so mnoj po-belorusski. Minsk	https://www.omniglot.com/writing/belarusian.htm	Cyrl
+Belarusian 2	bela1254	Violetta Ivanova	Peter Mayo. Belorussian. Bernard Comrie, Greville C. Corbett (eds.) The Slavonic Languages. London and New York, 1993.	https://www.omniglot.com/writing/belarusian.htm	Cyrl
+Bengali	beng1280	Anna Sorokina	Thompson, H.-R. (2012). Bengali. Amsterdam: John Benjamins Pub. Co.	https://www.omniglot.com/writing/bengali.htm	Beng
+Breton	bret1244	Tanya Masumi	Press I., Bihan H. Colloquial Breton: The complete course for beginners //FORUM FOR MODERN LANGUAGE STUDIES. – GREAT CLARENDON ST, OXFORD OX2 6DP, ENGLAND : OXFORD UNIV PRESS, 2005.	https://www.omniglot.com/writing/breton.htm	Latn
+Bulgarian 1	bulg1262	Darya Zubova	Maslov, Yu. S. (1981) Grammatika bolgarskogo yazyka. Moscow	https://www.omniglot.com/writing/bulgarian.htm	Cyrl
+Bulgarian 2	bulg1262	Violetta Ivanova	Ernest A. Scatton. Bulgarian. Bernard Comrie, Greville G. Corbett (eds.). The slavonic languages. 1993	https://www.omniglot.com/writing/bulgarian.htm	Cyrl
+Buryat	buri1258	Vyacheslav Ivanov	Sanzheev (red.) (1962) Grammatica buryatskogo yazika: Fonetica i morfologiya / Red. G.D. Sanzheev. Moscow	https://www.omniglot.com/writing/buryat.htm	Cyrl
+Catalan	stan1289	Tanya Masumi	Miyara Alberto José, Brunelli Mihele. Catalan Grammar / Грамматика каталанского языка	https://www.omniglot.com/writing/catalan.htm	Latn
+Chechen	chec1245	Anna Sorokina	Dotton, Z., Wagner, J. D. A grammar of Chechen.	https://www.omniglot.com/writing/chechen.htm	
+Cherokee	cher1273	Anna Verdieva	Montgomery-Anderson, 2008: 31-107	https://www.omniglot.com/writing/cherokee.htm	Cher
+Chipewyan	chip1261	Valeriia Kozenasheva	Li Fang-Kuei	https://www.omniglot.com/writing/chipewyan.htm	Latn
+chiTonga	chit1281	Anna Simonyan	Carter, H., & Kashoki, M. E. (2002). An outline of Chitonga grammar. Bookworld Pub House.	NA	Latn
+Comorian	como1260	Irina Astafyeva	Mohamed, M. A. (2001). Modern Swahili Grammar. East African Publishers.	https://www.omniglot.com/writing/comorian.htm	Arab
+Cornish	corn1251	Tanya Masumi	Smith A. S. D., Hooper E. G. R. Cornish simplified: short lessons for self-tuition: pronunciation, grammar, exercises. – Dyllansow Truran, 1972.	https://www.omniglot.com/writing/cornish.htm	Latn
+Crimean Tatar	crim1257	Vyacheslav Ivanov	Kavitskaya D. (2010) Crimean Tatar. Linkom Europa	https://www.omniglot.com/writing/crimeantatar.php	Cyrl
+Czech	czec1258	Violetta Ivanova	Laura A. Janda and Charles E. Towsend. Czech. 2000	https://www.omniglot.com/writing/czech.htm	Latn
+Danish	dani1285	Violetta Ivanova	Michael Herslund. Danish. Lincom Europa, 2002.	https://www.omniglot.com/writing/danish.htm	Latn
+Dargwa	darg1241	Anna Sorokina	Абдуллаев, С.Н. (1954). Грамматика даргинского языка (фонетика и морфология). Махачкала: Институт истории, языка и литературы Дагестанского филиала АН СССР.	https://www.omniglot.com/writing/dargwa.htm	Cyrl
+Dari	dari1249	Irina Astafyeva	Wahab, S. (2004). Beginner's Dari (Persian). Hippocrene Books.	https://www.omniglot.com/writing/dari.htm	Arab
+Dena’ina	tana1289	Valeriia Kozenasheva	Alan Boraas. (2009) An introduction to dena’ina grammar:  the kenai (outer inlet) dialect.	https://www.omniglot.com/writing/denaina.htm	Latn
+Dhivehi (Thaana)	dhiv1236	Anna Sorokina	Gnanadesikan, A. E., (2012). Maldivian Thaana, Japanese kana, and the representation of moras in writing, Writing Systems Research, 4:1, 91-102, DOI: 10.1080/17586801.2012.693459	https://www.omniglot.com/writing/thaana.htm	Thaa
+Dutch	dutc1256	Violetta Ivanova	Gerdi Quist, Dennis Strik. Teach Yourself Dutch. 2003	https://www.omniglot.com/writing/dutch.htm	Latn
+Enets	fore1265	Irina Astafyeva	Siegl F. Materials on Forest Enets, an indigenous language of Northern Siberia : дис. – 2011.	https://www.omniglot.com/writing/enets.htm	Cyrl
+English (BrE)	stan1293	Violetta Ivanova	Michael Swan. Practical English Usage. Oxford University Press, 2009. Rebecca M. Dauer. Accurate English: a complete course in pronunciation. Prentice Hall Regents, 1993.	https://www.omniglot.com/writing/english.htm	Latn
+Erzya	erzy1239	Irina Astafyeva	Г. Аитов. Новый алфавит. Великая революция на востоке. — Саратов: Нижневолжское краевое изд-во, 1932. — С. 61-64. — 73 с. — 3150 экз.	https://www.omniglot.com/writing/erzya.htm	Cyrl
+Estonian	esto1258	Irina Astafyeva	http://www.eki.ee/knn/ungegn/un7_gdl.htm	https://www.omniglot.com/writing/estonian.htm	Latn
+Ewe	ewee1241	Asya Simonyan	Warburton, I. (1968). Ewe basic course.	https://www.omniglot.com/writing/ewe.htm	Latn
+Eyak	eyak1241	Valeriia Kozenasheva	Michael E. Krauss (1965) Eyak: a preliminary report	https://www.omniglot.com/writing/eyak.php	Latn
+Faka-Tongan	tong1325	Nikita Shennikov	C. Maxwell Churchward, Tongan Grammar, 1985	https://www.omniglot.com/writing/tongan.htm	Latn
+Faroese	faro1244	Violetta Ivanova	Hjalmar P. Petersen and Jonathan Adams. Faroese. A Language Course for Beginners. Grammar. Stidin, 2009.	https://www.omniglot.com/writing/faroese.htm	Latn
+Fijian	fiji1243	Tanya Masumi	Dixon R. M. W. A grammar of Boumaa Fijian. – University of Chicago Press, 1988.	https://www.omniglot.com/writing/fijian.htm	Latn
+Finnish	finn1318	Irina Astafyeva	https://www.scribd.com/doc/316881341/Teach-Yourself-Finnish-1-pdf#fullscreen=1	https://www.omniglot.com/writing/finnish.htm	Latn
+French	stan1290	Tanya Masumi	Batchelor R. E., Chebli-Saadi M. A reference grammar of French. – Cambridge University Press, 2011.	https://www.omniglot.com/writing/french.htm	Latn
+Fula	adam1253	Asya Simonyan	Pelletier, C. A., & Skinner, A. N. (1981). Adawama Fulfulde. An introductory course. African Languages and Literature University of Wisconsin-Madison	https://www.omniglot.com/writing/fula.htm	Latn
+Futunan	east2447	Tanya Masumi	Diessel H. Demonstratives: Form, function and grammaticalization. – John Benjamins Publishing, 1999. – Т. 42.	https://www.omniglot.com/writing/futunan.htm	Latn
+Georgian (Mkhedruli)	nucl1302	Antonina Sinelnik	Aronson, Howard I. (1990). Georgian: a reading grammar	https://www.omniglot.com/writing/georgian2.htm	Geor
+German	stan1295	Violetta Ivanova	Bruce Donaldson. German. An Essential Grammar. Routledge: London and New York, 2007.	https://www.omniglot.com/writing/german.htm	Latn
+Hän	hann1241	Valeriia Kozenasheva	Patrick E. Marlow. 1997. Han phonology & morphology.	https://www.omniglot.com/writing/han.htm	Latn
+Hangul (Korean)	kore1280	Antonina Sinelnik	Lee, Hyun Bok (1999). Korean. Handbook of the International Phonetic Association	https://www.omniglot.com/writing/korean.htm	Hang
+Hanuno'o	hanu1241	Roman Tarasov	Conklin (1953) Hanunóo-English Vocabulary. Berkeley & Los-Angeles	https://omniglot.com/writing/hanunoo.htm	Hano
+Hawaiian	hawa1245	Nikita Shennikov	Elbert S.H., Pukui M.K., Hawaiian Grammar, 1979	https://www.omniglot.com/writing/hawaiian.htm	Latn
+Hebrew	hebr1245	Irina Astafyeva	Glinert, L. (2004). The grammar of modern Hebrew. Cambridge University Press.	https://www.omniglot.com/writing/hebrew.htm	Hebr
+Hindi (Devanāgarī)	hind1269	Anna Sorokina	Kachru, Y. (2006). Hindi. Philadelphia: John Benjamins Pub. Co.	https://www.omniglot.com/writing/hindi.htm	Deva
+Hungarian	hung1274	Irina Astafyeva	Törkenczy M. Hungarian verbs and essentials of grammar: a practical guide to the mastery of Hungarian. – Ntc Pub Group, 1997.	https://www.omniglot.com/writing/hungarian.htm	Latn
+Hupa	hupa1239	Valeriia Kozenasheva	Victor Karl Golla (1960). Hupa Grammar.	https://www.omniglot.com/writing/hupa.htm	Latn
+Icelandic	icel1247	Violetta Ivanova	Höskuldur Thráinsson. Icelandic. In Konig, E., & Van der Auwera, J. (2013). The germanic languages. Routledge. Hildur Jonsdottir. Teach yourself Icelandic. McGraw-Hill, 2004.	https://www.omniglot.com/writing/icelandic.htm	Latn
+Igbo	nucl1417	Nikita Shennikov	Fichman, B. S. (1975). Jazyk igbo. Izdat. Nauka.	https://www.omniglot.com/writing/igbo.htm	Latn
+Ingrian	ingr1248	Irina Astafyeva	http://lingvisto.org/files/ingrian.pdf	https://www.omniglot.com/writing/ingrian.htm	Latn
+Ingush	ingu1240	Arseniy Averin	Nichols J. Ingush Grammar. University of California, Berkeley. 2011	https://www.omniglot.com/writing/ingush.htm	Cyrl
+Inuktitut	east2534	Roman Tarasov	Rogers (2005) Writing Systems: a Linguistic Approach. pp.253-254	https://omniglot.com/writing/inuktitut.htm	Cans
+Irish	iris1253	Tanya Masumi	Doyle A. Irish, volume 201 of Languages of the World/Materials //Munich, Germany: LINCOM EUROPA. – 2001.	https://www.omniglot.com/writing/irish.htm	Latn
+Italian	ital1282	Tanya Masumi	Sandro Carnevali, Fonetica della lingua italiana  (1998-2007)	https://www.omniglot.com/writing/italian.htm	Latn
+Itbayat	ivat1242	Nikita Shennikov	Cesar A. Hidalgo, A Tagmemic Grammar of Ivatan, 1971	https://www.omniglot.com/writing/itbayat.htm	Latn
+Japanese (Hiragana)	nucl1643	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese_hiragana.htm	Hira
+Japanese (Katakana)	nucl1643	Kanami Tobe	Labrune, L. (2012). The phonology of Japanese. Oxford University Press.	https://www.omniglot.com/writing/japanese_katakana.htm	Kana
+Kabardian	kaba1278	Anna Sorokina	Matasović, R. (2010). A short grammar of East Circassian (Kabardian).	https://www.omniglot.com/writing/kabardian.htm	Cyrl
+Kalmyk	kalm1244	Vyacheslav Ivanov	Sanzheev G. D. (red.) Grammatika kalmytskogo yazyka. Fonetika i morfologiya. Elista	https://www.omniglot.com/writing/kalmyk.htm	Cyrl
+Kannada	nucl1305	Anna Sorokina	Spencer, H., & Perston, W. (1950). A Kanarese grammar: With graduated exercises. Mysore City, India: Wesley Press.	https://www.omniglot.com/writing/kannada.htm	Knda
+Kapingamarangi	kapi1249	Nikita Shennikov	Elbert S. , Kapingamarangi and Nukuoro Word List, With Notes on Linguistic Position, 1946 Pronunciation, and Grammar.	https://www.omniglot.com/writing/kapingamarangi.htm	Latn
+Karelian	kare1335	Irina Astafyeva	Zajkov P. M. Grammatika karelĘąskogo jazyka:(fonetika i morfologija). – Periodika, 1999.	https://www.omniglot.com/writing/karelian.htm	Latn
+Kazakh	kaza1248	Darya Zubova	Krippers, Karl A. (1997) Kazakh Grammar with Affix List	https://www.omniglot.com/writing/kazakh.htm	Cyrl
+Khakas	khak1248	Vyacheslav Ivanov	Dyrenkova N. P. (1948) Grammatica khakasskogo yazika. Abakan	https://www.omniglot.com/writing/khakas.htm	Cyrl
+Khmer	cent1989	Daria Demkina	Gorgoniev Y. A. Grammatika khmerskogo jazyka [A grammar of the Khmer language] //Moskva: Izdatel’stvo Nauka. Decorative symmetry in ritual (and everyday) language. – 1966. – Т. 585.	https://www.omniglot.com/writing/khmer.htm	Khmr
+Kichwa	colo1257	Alina Tillabayeva	Натаров А. Н. (2013) Грамматика языка кечуа	https://omniglot.com/writing/kichwa.htm	Latn
+Kikuyu	kiku1240	Asya Simonyan	Gecaga, B. M., & Kirkaldy-Willis, W. H. (1953). Short Kikuyu Grammar. Macmillan Kenya.	https://www.omniglot.com/writing/kikuyu.htm	Latn
+Komi-Permyak	komi1269	Irina Astafyeva	Лыткин В. И. (ред. ) Коми-пермяцкий язык. Введение, фонетика, лексика и морфология. Кудымкар: Коми-пермяцкое книжное издательство, 1962. - 340 с.	https://www.omniglot.com/writing/oldpermic.htm	Cyrl
+Koyukon	koyu1237	Valeriia Kozenasheva	Eliza Jones and Joe Kwaraceius (1997). Koyukon grammar.	https://www.omniglot.com/writing/koyukon.htm	Latn
+Kri	khap1242	Daria Demkina	Enfield N. J., Diffloth G. (2009) Phonology and sketch grammar of Kri, a Vietic language of Laos. Cahiers de linguistique Asie orientale	https://omniglot.com/writing/kri.htm	Latn
+Kurdish	kurd1259	Irina Astafyeva	McCarus, E. N. (2013). Kurdish. In The Iranian Languages (pp. 663-709). Routledge.	https://www.omniglot.com/writing/kurdish.htm	Arab
+Kwanyama	kuan1247	Asya Simonyan	Zimmermann, W., & Hasheela, P. (1998). Oshikwanyama grammar. Gamsberg Macmillan Publishers (Pty) Ltd..	https://www.omniglot.com/writing/oshiwambo.php	Latn
+Kyrgyz	kirg1245	Darya Zubova	Kara, D. S. (2003) Kyrgyz, Lincom Europa	https://www.omniglot.com/writing/kirghiz.htm	Cyrl
+Lak	lakk1252	Anna Sorokina	Schulze, W. (2007). The Lak Language — Лакку маз. A Quick Reference.	https://www.omniglot.com/writing/lak.htm	Cyrl
+Latvian	latv1249	Darya Zubova	Mathiassen, T. (1996) A short grammar of Latvian, Slavica Publishers	https://www.omniglot.com/writing/latvian.htm	Latn
+Lezgi	ezg1247	Anna Sorokina	Haspelmath, M. (1993). A grammar of Lezgian. Berlin; New York: Mouton de Gruyter.	https://www.omniglot.com/writing/lezgi.htm	Cyrl
+Lingala	ling1263	Asya Simonyan	Redden, J. & Bongo, F. (1963). Lingala, basic course. Washington: Department of State	https://www.omniglot.com/writing/lingala.htm	Latn
+Lithuanian	lith1251	Darya Zubova	Mathiassen, T. (1996) A short grammar of Lithuanian, Slavica Publishers	https://www.omniglot.com/writing/lithuanian.htm	Latn
+Lower Sorbian	lowe1385	Violetta Ivanova	Gerald Stone. Sorbian (Upper and Lower). In Bernard Comrie, Creville C. Corbett (eds). The Slavonic Languages. London and New York, Routledge. 2095	https://www.omniglot.com/writing/sorbian.htm	Latn
+Macedonian	mace1250	Darya Zubova	Friedman, V. (2001) Macedonian, SEELRC	https://www.omniglot.com/writing/macedonian.htm	Cyrl
+Malayalam	mala1464	Anna Sorokina	Asher, R. E., & Kumari, T. C. (1997). Malayalam.	https://www.omniglot.com/writing/malayalam.htm	Mlym
+Mangareva	mang1401	Nikita Shennikov	Ena Manuireva, Mangarevan - A Shifting Language, 2014	https://www.omniglot.com/writing/mangareva.htm	Latn
+Manx	manx1243	Tanya Masumi	Broderick G. Manx //The Celtic Languages. – Routledge, 2009. – С. 319-370.	https://www.omniglot.com/writing/manx.htm	Latn
+Maori	maor1246	Tanya Masumi	Williams W. L. First lessons in the Maori language with a short vocabulary.-- Trübner & Company, 1862.	https://www.omniglot.com/writing/maori.htm	Latn
+Mele-Fila	mele1250	Nikita Shennikov	Ross Clark, Mele Notes, 1975	https://www.omniglot.com/writing/mele-fila.htm	Latn
+Moksha	moks1248	Irina Astafyeva	Поляков О. Е. Русско-мокшанский разговорник //Саранск: Мордов. кн. изд-во. – 1993.	http://www.omniglot.com/writing/moksha.htm	Cyrl
+Moldovan	mold1248	Tanya Masumi	Краткая энциклопедия «Советская Молдавия» (Кишинёв, 1982)	https://www.omniglot.com/writing/moldovan.htm	Cyrl
+Mongolian	mong1331	Roman Tarasov	Bat-Ireedui (2015) Colloquial Mongolian. The Complete Course for Beginners	https://omniglot.com/writing/mongolian.htm	Mong
+Mongolian (Cyrillic)	mong1331	Vyacheslav Ivanov	Todaeva, B. Kh. (1951) Grammatika sovremennogo mongolskogo yazika. Moscow	https://www.omniglot.com/writing/mongolian.htm	Cyrl
+Moriori	mori1267	Nikita Shennikov	Herbert William Williams, Some Notes on the Language of the Chatham Islands, 1918	https://www.omniglot.com/writing/moriori.htm	Latn
+N'Ko	nkoa1234	Nikita Shennikov	The History of N’ko and its Role in Mande Transnational Identity: Words as Weapons, 2005	https://www.omniglot.com/writing/nko.htm	Nkoo
+Nanai	nana1257	Vyacheslav Ivanov	Avrorin, V. A. (1959) Grammatica nanajskogo jazyka. Moscow, Leningrad.	https://www.omniglot.com/writing/nanai.htm	Cyrl
+Navajo	nava1243	Valeriia Kozenasheva	Irvy W. Goossen (1995). Dine Bizaad: Speak, Read, Write Navajo.	https://www.omniglot.com/writing/navajo.htm	Latn
+Ndyuka (Latin)	suri1272	Arseniy Averin	Hutter G.L., Hutter M.L. Ndyuka. Routledge. 1994	https://www.omniglot.com/writing/ndjuka.htm	Latn
+Nganasan 1	ngan1291	Daria Demkina	Zhovnitskaja, S. N. (2009) Nganasanskij yazik. Krasnoyarsk	https://www.omniglot.com/writing/nganasan.htm	Cyrl
+Nganasan 2	ngan1291	Irina Astafyeva	Жовницкая-Турдагина С. Н. Ня’’ букварь. СПб., 1999.	https://www.omniglot.com/writing/nganasan.htm	Cyrl
+Niuafo'ou	niua1240	Nikita Shennikov	Akihisa Tsukamoto, The language of Niuafo'ou Island, 1988	https://www.omniglot.com/writing/niuafoou.htm	Latn
+Niuean	niue1239	Tanya Masumi	Tregear E., Smith S. P. Vocabulary and grammar of the Niué dialect of the Polynesian language. – J. Mackay, Government Printer, 1907	https://www.omniglot.com/writing/niuean.php	Latn
+Nivkh	gily1242	Roman Tarasov	Gashilova (2002) Nivkhskij yazik v tablitsax. Saint-Petersburg	https://omniglot.com/writing/nivkh.htm	Cyrl
+Northern Sami	norw1258	Irina Astafyeva	Svonni, E Mikael. Sámegiel-ruoŧagiel skuvlasátnelistu. — Sámiskuvlastivra, 1984. — P. III.	https://www.omniglot.com/writing/northernsami.htm	Latn
+Norwegian	nort2671	Violetta Ivanova	Margaretha Danbolt Simons. Teach Yourself Norwegian. 2004.	https://www.omniglot.com/writing/norwegian.htm	Latn
+Nukuoro	nuku1260	Nikita Shennikov	Vern Carroll, An Outline of the Structure of the Language of Nukuoro, 1965	https://www.omniglot.com/writing/nukuoro.htm	Latn
+Pacoh	paco1243	Daria Demkina	Watson R.,S., Canxóiq C. (2013) Pacoh – Vietnamese – English Dictionary. SIL International.	NA	Latn
+Panjabi (Gurmukhi)	west2386;panj1256	Anna Sorokina	Bhardwaj, M. (2012). Colloquial Panjabi. London: Routledge.	https://www.omniglot.com/writing/punjabi.htm	Guru
+Paraguayan Guarani	ara1311	Alina Tillabayeva	Estigarribia, B. (2017). A Grammar Sketch of Paraguayan Guarani. Guarani linguistics in the 21st century, 7-85.	https://www.omniglot.com/writing/guarani.htm	Latn
+Pashto	pash1269	Irina Astafyeva	Lehr, R. (2014). A descriptive grammar of Pashai: The language and speech community of Darrai Nur. The University of Chicago.	https://www.omniglot.com/writing/pashto.htm	Arab
+Persian (Braille)	fars1254	Roman Tarasov	UNESCO (2013) World Braille Usage. Washington,D.C.	https://omniglot.com/writing/braille.htm	Brai
+Persian 1	fars1254	Tanya Masumi	Perry J. R., Windfuhr G. Persian and Tajik //The Iranian Languages. – Routledge, 2013. – С. 492-620	https://www.omniglot.com/writing/persian.htm	Arab
+Persian 2	fars1254	Irina Astafyeva	Perry, J. R., & Windfuhr, G. (2013). Persian and Tajik. In The Iranian Languages (pp. 492-620). Routledge.	https://www.omniglot.com/writing/persian.htm	Arab
+Polish	poli1260	Violetta Ivanova	Sadowska. Polish. A Comprehensive Grammar. Routledge: London and New York. 2012.	https://www.omniglot.com/writing/polish.htm	Latn
+Portuguese	port1283	Tanya Masumi	Izabel Christine Seara, Vanessa Gonzaga, Cristiane Lazzarotto-Volcão. Fonética e Fonologia do Português Brasileiro - Florianópolis, 2011	https://www.omniglot.com/writing/portuguese.htm	Latn
+Pukapukan	puka1242	Nikita Shennikov	Teingo W. A., Introduction to the Pukapukan Language, 1993	https://www.omniglot.com/writing/pukapukan.htm	Latn
+Rarotongan	maor1246	Nikita Shennikov	Maki'uti Tongia, Learning Rarotonga Maori, 1999	https://www.omniglot.com/writing/rarotongan.htm	Latn
+Rennellese	renn1242	Nikita Shennikov	Samuel H. Elbert, Dictionary of the Language of Rennell and Bellona, 1975	https://www.omniglot.com/writing/rennellese.htm	Latn
+Romanian	roma1327	Tanya Masumi	Cojocaru D. Romanian grammar. – Slavic and East European Language Research Center (SEELRC), Duke University, 2003.	https://www.omniglot.com/writing/romanian.htm	
+Romansch	roma1326	Tanya Masumi	Caduff R., Caprez U. N., Darms G. Grammatica d'instrucziun dal rumantsch grischun. – Department da linguatgs e litteraturas romanas, 2006.	https://www.omniglot.com/writing/romansh.htm	
+Russian	russ1263	Violetta Ivanova	Князев С.В., Пожарицкая С.К. Современный русский литературный язык. Фонетика, орфоэпия, графика и орфография. М.: Гаудеамус, 2011.	https://www.omniglot.com/writing/russian.htm	Cyrl
+Rutul (Cyrillic)	rutu1240	Arseniy Averin	Clarkson J., Iurkova E. Important Factors in the Development of an Orthography: Shin-Shorsu Rutul — a Case Study. Dallas, SIL International, 2015	https://www.omniglot.com/writing/rutul.htm	Cyrl
+Rutul (Latin)	rutu1240	Arseniy Averin	Clarkson J., Iurkova E. Important Factors in the Development of an Orthography: Shin-Shorsu Rutul — a Case Study. Dallas, SIL International, 2015	https://www.omniglot.com/writing/rutul.htm	Latn
+Samoan	samo1305	Tanya Masumi	Neffgen H. Grammar and Vocabulary of the Samoan Language, Together with Remarks on Some of the Points of Similarity Between the Samoan and the Tahitian and Maori Languages. – Ams PressInc, 1978. – Т. 30.	https://www.omniglot.com/writing/samoan.htm	Latn
+Sarcee	sars1236	Valeriia Kozenasheva	Eung-Do Cook (1984). A Sarcee grammar. Vancouver.	https://www.omniglot.com/writing/tsuutina.htm	Latn
+Scottish Gaelic	scot1245	Tanya Masumi	Gillies W. Scottish Gaelic //The Celtic Languages. – Routledge, 2009. – С. 244-318.	https://www.omniglot.com/writing/gaelic.htm	Latn
+Serbian	serb1264	Darya Zubova	Hammond, L. (2005) Serbian. An Essential Grammar. Routledge, London and New York	https://omniglot.com/writing/serbian.htm	Cyrl
+seSotho	sout2807	Anna Simonyan	Paroz, R. A. (1946). Elements of Southern Sotho. Basutoland, Morija Sesuto Book Depot.	https://www.omniglot.com/writing/latin.htm	Latn
+seTswana	tswa1253	Anna Simonyan	Peace Corps Botswana(2008). An Introduction to the Setswana Language	https://www.omniglot.com/writing/latin.htm	Latn
+Shor	shor1247	Vyacheslav Ivanov	Dyrenkova N. P. (1941) Grammatika shorskogo yazyka. Moscow, Leningrad	http://www.omniglot.com/writing/cyrillic.htm	Cyrl
+Sikaiana	sika1261	Nikita Shennikov	Donner W.,  LINGUA FRANCA AND VERNACULAR: LANGUAGE USE AND LANGUAGE CHANGE ON SIKAIANA, 1996	https://www.omniglot.com/writing/sikaiana.htm	Latn
+Sinhala	sinh1246	Anna Sorokina	Chandralal, D. (2010). Sinhala. Amsterdam: John Benjamins Pub. Co.	https://www.omniglot.com/writing/sinhala.htm	Sinh
+siSwati	swat1243	Anna Simonyan	Corum, C. W. (1978). An Introduction to the Swazi (siSwati) Language.	https://www.omniglot.com/writing/swati.php	Latn
+Skolt Sami	skol1241	Irina Astafyeva	Korhonen, Mikko. Mosnikoff, Jouni. Sammallahti, Pekka. Koltansaamen opas. Castreanumin toimitteita, Helsinki 1973.	https://www.omniglot.com/writing/skoltsami.htm	Latn
+Slovak	slov1269	Violetta Ivanova	David Short. Slovak. In Bernard Comrie, Creville C. Corbett (eds). The Slavonic Languages. London and New York, Routledge. 1993	https://www.omniglot.com/writing/slovak.htm	Latn
+Slovenian	slov1268	Violetta Ivanova	Peter Herrity. Slovene. A comprehensive grammar. Routledge. 2000	https://www.omniglot.com/writing/slovene.htm	Latn
+Somali (Abjad)	soma1255	Irina Astafyeva	Saeed, J. (1999). Somali (Vol. 10). John Benjamins Publishing.	https://www.omniglot.com/writing/somali.htm	Arab
+Somali (Latin)	soma1255	Irina Astafyeva	Saeed, J. (1999). Somali (Vol. 10). John Benjamins Publishing.	https://www.omniglot.com/writing/somali.htm	Latn
+Sorani	cent1972	Irina Astafyeva	Thackston, W. M. (2006). Kurmanji Kurdish:-A Reference Grammar with Selected Readings. Renas Media.	https://www.omniglot.com/writing/kurdish.htm	Arab
+Southern Sami	sout2674	Irina Astafyeva	Vangberg – Brandsfjell: Saemesth amma! Gïelemaahtotje - Liten grammatikk. Sijti Jarnge 2009.	https://www.omniglot.com/writing/southernsami.htm	Latn
+Spanish	stan1288	Tanya Masumi	Garrido, J. M., Machuca, M. J. y de la Mota, C. (1998). Prácticas de fonética. Lengua española I. Bellaterra: Universitat Autònoma de Barcelona.	https://www.omniglot.com/writing/spanish.htm	Latn
+Swahili	swah1253	Asya Simonyan	Russell, J. (1996). Swahili (Teach Yourself).	https://www.omniglot.com/writing/swahili.htm	Latn
+Swedish	swed1254	Violetta Ivanova	Vera Croghan. Swedish (Teach Yourself). 1995.	https://www.omniglot.com/writing/swedish.htm	Latn
+Syriac	clas1252	Irina Astafyeva	Muraoka, T. (2005). Classical Syriac: a basic grammar with a chrestomathy (Vol. 19). Otto Harrassowitz Verlag.	https://www.omniglot.com/writing/syriac.htm	Syrc
+Tabasaran	taba1259	Anna Sorokina	Алексеев, М.Е., Шихалиева, С.Х. (2003). Табасаранский язык. Языки народов России. Москва: Academia.	httpsː//www.omniglot.com/writing/tabassaran.htm	Cyrl
+Tahitian	tahi1242	Tanya Masumi	Burbidge G. W. A new grammar of the Tahitian dialect of the Polynesian language: And combined with a vocabulary of English, French, Tahitian //Papeete, Tahiti, French Polynesia, Church of Jesus Christ of Latter-Day Saints. – 1930.	https://www.omniglot.com/writing/tahitian.htm	Latn
+Tajik 1	taji1245	Tanya Masumi	Perry J. R., Windfuhr G. Persian and Tajik //The Iranian Languages. – Routledge, 2013. – С. 492-620	https://www.omniglot.com/writing/tajik.htm	Cyrl
+Tajik 2	taji1245	Darya Zubova	Ido, Sh. (2005) Tajik, Lincom Europa	https://www.omniglot.com/writing/tajik.htm	Cyrl
+Tamil	tami1289	Anna Verdieva	Andronov, M. S. (1965). The Tamil Language. Nauka.	https://www.omniglot.com/writing/tamil.htm	Taml
+Tao	taoo1239	Nikita Shennikov	Rau, D. Victoria, Maa-Neu Dong,  Yami texts with reference grammar and dictionary, 2006	https://www.omniglot.com/writing/yami.htm	Latn
+Telugu	telu1262	Anna Sorokina	Krishnamurti, B., & Gwynn, J. P. L. (1985). A grammar of modern Telugu. Delhi: Oxford University Press.	https://www.omniglot.com/writing/telugu.htm	Telu
+Temne	timn1235	Asya Simonyan	Peace Corps Sierra Leone (1987). Temne Language Manual.	https://www.omniglot.com/writing/temne.htm	Latn
+Ter Sami	ters1235	Irina Astafyeva	Куруч Р. Д. Краткий грамматический очерк саамского языка //РД Куруч (ред.). Саамско-русский словарь. М: Русский язык. – 1985. – С. 529-567.	https://www.omniglot.com/writing/tersami.htm	Cyrl
+Tibetan	tibe1272	Anna Verdieva	Tournade N. (2003) Manual of Standard Tibetan +AC0- Language and Civilization/ Nicolas Tournade, Sangda Dorje +AC0- Ithaca, NY: Snow Lion Publications.	https://www.omniglot.com/writing/tibetan.htm	Tibt
+Tigre (Abjad)	tigr1270	Irina Astafyeva	Raz, S. (1983). Tigre grammar and texts (Vol. 4). Undena Publications.	https://www.omniglot.com/writing/tigre.htm	Arab
+Tigre (Geez)	tigr1270	Irina Astafyeva	Raz, S. (1983). Tigre grammar and texts (Vol. 4). Undena Publications.	https://www.omniglot.com/writing/tigre.htm	Ethi
+Tigrinya	tigr1271	Irina Astafyeva	Mason, J. S. (Ed.). (1996). Tigrinya grammar. Red Sea Press (NJ).	https://www.omniglot.com/writing/tigrinya.htm	Ethi
+Tikopia	tiko1237	Nikita Shennikov	Firth Raymond, Tikopia-English Dictionary, 1985	https://www.omniglot.com/writing/tikopia.htm	Latn
+Tokelauan	toke1240	Nikita Shennikov	Hooper Robin, Studies in Tokelauan syntax, 1994	https://www.omniglot.com/writing/tokelauan.htm	Latn
+Tsonga	tson1249	Anna Simonyan	Ouwehand, M. (1965). Everyday Tsonga. Swiss Mission in South Africa.	https://www.omniglot.com/writing/tsonga.php	Latn
+Turkish	nucl1301	Vyacheslav Ivanov	Göksel A., Kerslake C. (2004) Turkish: A Comprehensive Grammar. London	https://www.omniglot.com/writing/turkish.htm	Latn
+Tuvaluan	tuva1244	Nikita Shennikov	Niko Besnier, Tuvaluan: A Polynesian Language of the Central Pacific, 2000	https://www.omniglot.com/writing/tuvaluan.htm	Latn
+Tuvan	tuvi1240	Vyacheslav Ivanov	Iskhakov, F. G., Palmbakh, A. A. (1961) Grammatica tuvinskogo yazika. Fonetica i morfologiya. Moscow	https://www.omniglot.com/writing/cyrillic.htm	Cyrl
+Udmurt	udmu1245	Irina Astafyeva	И. В. Тараканов. Алфавит. — Удмуртская Республика: Энциклопедия. — Ижевск : Удмуртия, 2000. — С. 168. — 800 с.	https://www.omniglot.com/writing/udmurt.htm	Cyrl
+Ukrainian 1	ukra1253	Darya Zubova	Danyenko, A., Vakylenko, S. (1995) Ukranian, Lincom Europa, M_nchen-Newcastle	https://www.omniglot.com/writing/ukrainian.htm	Cyrl
+Ukrainian 2	ukra1253	Violetta Ivanova	Stefan M. Pugh and Ian Press. Ukrainian. A comprehensive grammar. 1999	https://www.omniglot.com/writing/ukrainian.htm	Cyrl
+Upper Sorbian	uppe1395	Violetta Ivanova	Gerald Stone. Sorbian (Upper and Lower). In Bernard Comrie, Creville C. Corbett (eds). The Slavonic Languages. London and New York, Routledge. 2095	https://www.omniglot.com/writing/sorbian.htm	Latn
+Urdu	urdu1245	Irina Astafyeva	Delacy, R. (2003). Teach Yourself Beginner's Urdu Script. Teach Yourself.	https://www.omniglot.com/writing/urdu.htm	Arab
+Uzbek	uzbe1247	Darya Zubova	Ibragimov, S. I. (1972) Voprosy sovershenstvovaniya alfavitov tyurkskih yazykov SSSR, Moscow	https://www.omniglot.com/writing/uzbek.htm	Cyrl
+Vaeakau-Taumako	pile1238	Nikita Shennikov	Næss A., Hovdhaugen E, A grammar of Vaeakau-Taumako, 2011	https://www.omniglot.com/writing/vaeakautaumako.htm	Latn
+Vai	vaii1241	Nikita Shennikov	S. Lamii Tucker, 1999	https://www.omniglot.com/writing/vai.htm	Vaii
+Vananga rapa nui	rapa1244	Nikita Shennikov	Paulus-Jan Kieviet, A grammar of Rapa Nui, 2017	https://www.omniglot.com/writing/rapanui.htm	Latn
+Vietnamese	viet1252	Daria Demkina	Thompson, L. C. (1987). A Vietnamese reference grammar (Vol. 13). University of Hawaii Press.	https://omniglot.com/writing/vietnamese.htm	Latn
+Võro	voro1241	Irina Astafyeva	https://linguapedia.info/languages/voro.html	https://www.omniglot.com/writing/voro.htm	Latn
+Wa	waaa1245	Daria Demkina	Mai M. S.(2012) A Descriptive Grammar of Wa. Payap University.	https://omniglot.com/writing/wa.htm	Latn
+Wallisian	wall1257	Nikita Shennikov	Tsukamoto Akihisa, The language of Niuafo'ou Island, 1988	https://www.omniglot.com/writing/wallisian.htm	Latn
+Welsh	wels1247	Tanya Masumi	Awbery G. Welsh. – na, 2009.	https://www.omniglot.com/writing/welsh.htm	Latn
+Wolof	nucl1347	Asya Simonyan	Peace Corps The Gambia (1995). Wollof Grammar Manual.	https://www.omniglot.com/writing/wolof.htm	Latn
+Xhosa	xhos1239	Anna Simonyan	Kirsch, B., Skorge, S., & Magona, S. (2003). Teach Yourself Xhosa. Hodder Headline.	https://www.omniglot.com/writing/xhosa.htm	Latn
+Yakut	yaku1245	Vyacheslav Ivanov	Kharitonov, L. N. (1947) Sovremennyj yakutskij yazyk: Fonetika i morfologiya. Yakutsk	https://www.omniglot.com/writing/yakut.htm	Cyrl
+Yapese	yape1248	Tanya Masumi	Phillips L. // Yapese Alphabet.-- Pacific Resources for Education and Learning, 2006	https://www.omniglot.com/writing/yapese.htm	Latn
+Yiddish	yidd1255	Violetta Ivanova	Dovid Katz. Grammar of the Yiddish Language. Duckworth, 1987.	https://www.omniglot.com/writing/yiddish.htm	Hebr
+Yoruba	yoru1245	Nikita Shennikov	Ọladele A. 1978 Essentials of Yoruba grammar	https://www.omniglot.com/writing/yoruba.htm	Latn
+Zulu 1	zulu1248	Anna Simonyan	Wilkes, A., & Nkosi, N. (2003). Zulu. Teach Yourself.	https://omniglot.com/writing/zulu.htm	Latn
+Zulu 2	zulu1248	Roman Tarasov	Doke. Vilakazi (1972) Zulu-English Dictionary. Johannesburg	https://omniglot.com/writing/zulu.htm	Latn

--- a/database.csv
+++ b/database.csv
@@ -2839,316 +2839,316 @@ Tamil,ூ,uː,with ட் ம் ர் ழ் ள்,"M. S. Andronov, 1965: 14-
 Tamil,ூ,uː,with ங் ப் ய் வ்,"M. S. Andronov, 1965: 14-20",http://www.omniglot.com/writing/tamil.htm
 Tamil,ூ,uː,with ச்,"M. S. Andronov, 1965: 14-20",http://www.omniglot.com/writing/tamil.htm
 Tamil,ூ,uː,with க்,"M. S. Andronov, 1965: 14-20",http://www.omniglot.com/writing/tamil.htm
-Mongolian cyrillic,А,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Аа,aː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,а,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,аа,аː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,В,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,в,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,З,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,з,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,И,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,и,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,иа,aː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ио,oː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,М,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,м,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,н,ŋ,"в абсолютном конце слова, а также  перед г",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,О,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,о,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,П,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,п,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,С,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,с,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,У,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,у,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ы,ɯ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,Яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Mongolian cyrillic,яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
-Japanese Hiragana,あ,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,い,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,う,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,え,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,お,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,か,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,き,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,く,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,け,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,こ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,さ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,し,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,す,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,せ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,そ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,た,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ち,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,つ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,て,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,と,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,な,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,に,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぬ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ね,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,の,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,は,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ふ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,へ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ほ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ま,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,み,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,む,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,め,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,も,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,や,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ゆ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,よ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ら,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,り,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,る,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,れ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ろ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,わ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,を,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ん,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,が,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぐ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,げ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ご,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ざ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ず,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぜ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぞ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,だ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,づ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,で,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ど,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ば,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,び,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぶ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,べ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぼ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぱ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぷ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぺ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぽ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,きゃ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,きゅ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,きょ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎゃ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎゅ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぎょ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,しゃ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,しゅ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,しょ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,じょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ちゃ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ちゅ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ちょ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぢょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,にゃ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,にゅ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,にょ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひゃ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひゅ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ひょ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴゃ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴゅ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,ぴょ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,びゃ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,びゅ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,びょ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,みゃ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,みゅ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,みょ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,りゃ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,りゅ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Hiragana,りょ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Katakana,ア,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
-Japanese Katakana,イ,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ウ,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,エ,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,オ,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,カ,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キ,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ク,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ケ,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,コ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,サ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,シ,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ス,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,セ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ソ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,タ,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チ,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ツ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,テ,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ト,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ナ,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニ,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヌ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ネ,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ノ,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ハ,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,フ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヘ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ホ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,マ,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミ,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ム,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,メ,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,モ,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヤ,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ユ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヨ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ラ,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リ,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ル,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,レ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ロ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ワ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヲ,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ン,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ガ,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,グ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゲ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゴ,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ザ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゼ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ゾ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ダ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,デ,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ド,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,バ,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビ,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ブ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ベ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ボ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,パ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,プ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ペ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ポ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キャ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キュ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,キョ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギャ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギュ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ギョ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,シャ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,シュ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ショ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ジョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チャ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チュ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,チョ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヂョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニャ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニュ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ニョ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒャ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒュ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ヒョ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピャ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピュ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ピョ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビャ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビュ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ビョ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミャ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミュ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,ミョ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リャ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リュ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
-Japanese Katakana,リョ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Mongolian (Cyrillic),А,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Аа,aː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),а,a,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),аа,аː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ай,aɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),б,b,"только в абсолютном начале слова и после [m], [ɬ], [v]",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),В,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),в,w,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),г,ɡ,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),д,d,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),е,je,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ё,jo,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ж,d͡ʒ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),З,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),з,d͡z,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),И,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),и,i,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ий,iɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),иа,aː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ио,oː,после мягких согласных,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),й,j,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),л,ɬ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),М,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),м,m,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),н,n,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),н,ŋ,"в абсолютном конце слова, а также  перед г",Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),О,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),о,o,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),оо,oː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ой,oɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ө,ø,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),өө,øː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),П,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),п,p,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),р,r,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),С,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),с,s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),т,t,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),У,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),у,u,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),уу,uː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),уй,uɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ү,ʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),үү,ʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),үй,ʉɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),х,x,в словах с гласными переднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),х,χ,в словах с гласными заднего ряда,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ц,t͡s,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ч,t͡ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ш,ʃ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ы,ɯ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),эй,eɪ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),э,e,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ээ,eː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ю,ju,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),ю,jʉ,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),юу,juː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),юу,jʉː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),Яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),я,ja,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Mongolian (Cyrillic),яа,jaː,,Todaeva 1951: 13-33,http://www.omniglot.com/writing/mongolian.htm
+Japanese (Hiragana),あ,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),い,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),う,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),え,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),お,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),か,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),き,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),く,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),け,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),こ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),さ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),し,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),す,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),せ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),そ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),た,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ち,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),つ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),て,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),と,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),な,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),に,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぬ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ね,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),の,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),は,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ふ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),へ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ほ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ま,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),み,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),む,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),め,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),も,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),や,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ゆ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),よ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ら,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),り,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),る,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),れ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ろ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),わ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),を,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ん,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),が,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぐ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),げ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ご,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ざ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ず,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぜ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぞ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),だ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),づ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),で,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ど,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ば,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),び,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぶ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),べ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぼ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぱ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぷ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぺ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぽ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),きゃ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),きゅ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),きょ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎゃ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎゅ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぎょ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),しゃ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),しゅ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),しょ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),じょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ちゃ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ちゅ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ちょ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢゃ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢゅ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぢょ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),にゃ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),にゅ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),にょ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひゃ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひゅ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ひょ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴゃ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴゅ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),ぴょ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),びゃ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),びゅ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),びょ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),みゃ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),みゅ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),みょ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),りゃ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),りゅ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Hiragana),りょ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Katakana),ア,a,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_hiragana.htm
+Japanese (Katakana),イ,i,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ウ,ɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),エ,e,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),オ,o,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),カ,ka,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キ,kʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ク,kɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ケ,ke,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),コ,ko,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),サ,sa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),シ,ɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ス,sɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),セ,se,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ソ,so,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),タ,ta,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チ,tɕi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ツ,tsɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),テ,te,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ト,to,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ナ,,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニ,ɲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヌ,nɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ネ,ne,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ノ,no,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ハ,ha,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒ,çi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),フ,ɸɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヘ,he,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ホ,ho,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),マ,ma,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミ,mʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ム,mɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),メ,me,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),モ,mo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヤ,ja,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ユ,jɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヨ,jo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ラ,ɾa],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リ,ɾʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ル,ɾɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),レ,ɾe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ロ,ɾo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ワ,ɰa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヲ,ɰo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ン,/N/,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ガ,ɡa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),グ,ɡɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゲ,ɡe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゴ,ɡo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ザ,dza,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゼ,dze,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ゾ,dzo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ダ,da,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂ,dʑi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ズ,dzɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),デ,de,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ド,do,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),バ,ba,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビ,bʲi,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ブ,bu,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ベ,be,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ボ,bo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),パ,pa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピ,pʲi],,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),プ,pɯ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ペ,pe,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ポ,po,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キャ,kʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キュ,kʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),キョ,kʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギャ,ɡʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギュ,ɡʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ギョ,ɡʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),シャ,ɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),シュ,ɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ショ,ɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ジョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チャ,tɕʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チュ,tɕʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),チョ,tɕʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂャ,ʑʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂュ,ʑʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヂョ,ʑʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニャ,ɲʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニュ,ɲʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ニョ,ɲʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒャ,çʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒュ,çʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ヒョ,çʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピャ,pʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピュ,pʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ピョ,pʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビャ,bʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビュ,bʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ビョ,bʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミャ,mʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミュ,mʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),ミョ,mʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リャ,ɾʲa,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リュ,ɾʲɨ,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
+Japanese (Katakana),リョ,ɾʲo,,"Labrune, 2012: 29, 38, 69, 73, 149",https://www.omniglot.com/writing/japanese_katakana.htm
 Crimean Tatar,А,a,,Kavitskaya 2010: 5-17,https://www.omniglot.com/writing/crimeantatar.php
 Crimean Tatar,а,a,,Kavitskaya 2010: 5-17,https://www.omniglot.com/writing/crimeantatar.php
 Crimean Tatar,Б,b,,Kavitskaya 2010: 5-17,https://www.omniglot.com/writing/crimeantatar.php
@@ -3803,7 +3803,7 @@ Kri,p,p,На конце слова pˀ,"Enfield, Diffloth 2009: 8-34",http://omn
 Kri,ph,pʰ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,qj,ʄ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,R,r~ʐ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
-kri,r,r~ʐ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
+Kri,r,r~ʐ,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,S,s,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,s,s,,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
 Kri,T,t,На конце слова tˀ,"Enfield, Diffloth 2009: 8-34",http://omniglot.com/writing/kri.htm
@@ -6873,143 +6873,143 @@ Lower Sorbian,ž,ʒ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com
 Lower Sorbian,ž,ʃ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
 Lower Sorbian,Ź,ʑ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
 Lower Sorbian,ź,ʑ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
-Persian ,ـئ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian , ـؤ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـأ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـئـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ئـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian , أ,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ء,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـا,ɒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,آ ,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian , ا,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـب,b,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـبـ,b,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,بـ,b,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ب,b,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـپ,p,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـپـ,p,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,پـ,p,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,پ,p,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـت,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـتـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,تـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ت,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـث,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـثـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ثـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ث,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـج,d͡ʒ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـجـ,d͡ʒ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,جـ,d͡ʒ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ج,d͡ʒ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـچ,t͡ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـچـ,t͡ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,چـ,t͡ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,چ,t͡ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـح,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـحـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,حـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ح,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـخ,x,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـخـ,x,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,خـ,x,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,خ,x,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـد,d,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,د,d,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـذ,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ذ,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـر,ɾ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ر,ɾ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـز,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ز,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـژ,ʒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ژ,ʒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـس,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـسـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,سـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,س,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـش,ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـشـ,ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,شـ,ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ش,ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـص,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـصـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,صـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ص,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـض,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـضـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ضـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ض,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـط,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـطـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,طـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ط,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـظ,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـظـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ظـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ظ,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـع,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـعـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,عـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ع,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـغ,ɣ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـغـ,ɣ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,غـ,ɣ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,غ,ɣ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـف,f,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـفـ,f,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,فـ,f,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ف,f,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـق,ɢ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـقـ,ɢ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,قـ,ɢ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ق,ɢ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـک,k,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـکـ,k,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,کـ,k,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ک,k,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـگ,ɡ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـگـ,ɡ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,گـ,ɡ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,گ,ɡ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـل,l,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـلـ,l,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,لـ,l,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ل,l,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـم,m,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـمـ,m,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,مـ,m,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,م,m,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـن,n,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـنـ,n,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,نـ,n,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ن,n,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,v,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,ow,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,u,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـو,o,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,و,v,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,و,u,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,و,ow,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـه,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـه,e,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـه,a,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـهـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,هـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ه,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـی,y,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـی,i,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـی,ey,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـیـ,y,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـیـ,i,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ـیـ,ey,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,یـ,y,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,یـ,i,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,یـ,ey,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ی,y,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ی,i,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian ,ی,ey,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـئ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian, ـؤ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـأ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـئـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ئـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian, أ,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ء,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـا,ɒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,آ ,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian, ا,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـب,b,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـبـ,b,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,بـ,b,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ب,b,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـپ,p,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـپـ,p,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,پـ,p,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,پ,p,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـت,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـتـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,تـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ت,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـث,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـثـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ثـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ث,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـج,d͡ʒ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـجـ,d͡ʒ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,جـ,d͡ʒ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ج,d͡ʒ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـچ,t͡ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـچـ,t͡ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,چـ,t͡ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,چ,t͡ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـح,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـحـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,حـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ح,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـخ,x,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـخـ,x,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,خـ,x,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,خ,x,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـد,d,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,د,d,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـذ,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ذ,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـر,ɾ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ر,ɾ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـز,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ز,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـژ,ʒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ژ,ʒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـس,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـسـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,سـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,س,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـش,ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـشـ,ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,شـ,ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ش,ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـص,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـصـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,صـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ص,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـض,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـضـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ضـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ض,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـط,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـطـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,طـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ط,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـظ,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـظـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ظـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ظ,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـع,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـعـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,عـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ع,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـغ,ɣ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـغـ,ɣ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,غـ,ɣ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,غ,ɣ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـف,f,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـفـ,f,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,فـ,f,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ف,f,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـق,ɢ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـقـ,ɢ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,قـ,ɢ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ق,ɢ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـک,k,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـکـ,k,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,کـ,k,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ک,k,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـگ,ɡ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـگـ,ɡ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,گـ,ɡ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,گ,ɡ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـل,l,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـلـ,l,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,لـ,l,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ل,l,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـم,m,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـمـ,m,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,مـ,m,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,م,m,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـن,n,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـنـ,n,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,نـ,n,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ن,n,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,v,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,ow,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,u,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـو,o,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,و,v,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,و,u,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,و,ow,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـه,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـه,e,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـه,a,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـهـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,هـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ه,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـی,y,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـی,i,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـی,ey,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـیـ,y,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـیـ,i,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ـیـ,ey,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,یـ,y,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,یـ,i,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,یـ,ey,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ی,y,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ی,i,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian,ی,ey,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
 Tadjik,А,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
 Tadjik,а,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
 Tadjik,Б,b,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
@@ -10125,70 +10125,70 @@ Ainu Katakana,ㇾ,-le,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Ainu Katakana,セ゚,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Ainu Katakana,ツ゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Ainu Katakana,ト゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Aymar,A,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,I,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,J,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,K,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,K’,k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,L,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,M,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,N,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,P,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,P’,p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Q,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Q’,q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,R,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,S,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,T,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,T’,t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,U,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,W,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,X,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,Y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,a,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,i,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,j,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,k,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,k',k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,l,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,m,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,n,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p',p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,h,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p',q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,r,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,s,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,t,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,p',t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,u,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,w,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,x,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
-Aymar,y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,A,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,I,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,J,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,K,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,K’,k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,L,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,M,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,N,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,P,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,P’,p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Q,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Q’,q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,R,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,S,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,T,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,T’,t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,U,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,W,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,X,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,Y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,a,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ch',ʧ’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,chh,ʧʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,i,i,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ï,iː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,j,x,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,k,k,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,k',k’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,kh,kʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,l,l,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ll,ʎ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,m,m,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,n,n,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ñ,ɲ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p,p,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p',p’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ph,pʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,h,q,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p',q’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,qh,qʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,r,ɾ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,s,s,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,t,t,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,p',t’,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,th,tʰ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,u,u,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,ü,uː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,w,w,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,x,χ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
+Aymara,y,j,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
 Paraguayan Guarani,A,a,,[Estigarribia 2017],https://www.omniglot.com/writing/guarani.htm
 Paraguayan Guarani,À,a,под ударением и не поседний слог,[Estigarribia 2017],https://www.omniglot.com/writing/guarani.htm
 Paraguayan Guarani,Ã,ã,,[Estigarribia 2017],https://www.omniglot.com/writing/guarani.htm
@@ -11861,136 +11861,136 @@ Dargwa,Ь,j,in russian loanwords,Абдуллаев 1954: 23-30.,https://www.omn
 Dargwa,Э,e,,Абдуллаев 1954: 23-30.,https://www.omniglot.com/writing/dargwa.htm
 Dargwa,Ю,ju,,Абдуллаев 1954: 23-30.,https://www.omniglot.com/writing/dargwa.htm
 Dargwa,Я,ə,,Абдуллаев 1954: 23-30.,https://www.omniglot.com/writing/dargwa.htm
-Kabardian (East Circassian),а,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),в,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),з,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),и,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),и,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),к,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),м,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),о,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),о,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ӏ,ʔ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ӏу,ʔʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),п,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),с,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),у,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),у,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),А,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),В,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),З,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),И,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),И,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),К,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),М,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),О,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),О,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),П,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),С,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),У,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),У,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
-Kabardian (East Circassian),Я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,а,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,в,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,з,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,и,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,и,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,к,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,м,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,о,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,о,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ӏ,ʔ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ӏу,ʔʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,п,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,с,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,у,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,у,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,А,aː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Б,b,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,В,v,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Г,ɡ,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Г,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Гу,ɡʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Гъ,ʁ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Гъу,ʁʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Д,d,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Дж,ɡʲ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Дж,d͡ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Дз,d͡z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Е,aj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Е,ja,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ё,jo,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ж,ʒ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Жь,ʑ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,З,z,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,И,əj,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,И,jə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Й,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,К,k2,only in loanwords,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кӏ,kʲʼ,some dialects,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кӏу,kʷʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ку,kʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кхъ,q͡χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Кхъу,q͡χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Къ,q,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Къу,qʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Л,ɮ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Лӏ,ɬʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Лъ,ɬ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,М,m,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Н,n,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,О,aw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,О,wa,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Пӏ,pʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,П,p,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Р,r,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,С,s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Т,t,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Тӏ,tʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,У,w,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,У,əw,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ф,f,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Фӏ,fʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Х,x,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ху,xʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Хъ,χ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Хъу,χʷ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Хь,ħ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ц,t͡s,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Цӏ,t͡sʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ч,t͡ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Чӏ,t͡ʃʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ш,ʃ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Щ,ɕ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Щӏ,ɕʼ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ъ,ɣ,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ь,j,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ы,ə,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Э,a,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Ю,ju,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
+Kabardian,Я,jaː,,Matasović 2010: 9-11.,http://www.omniglot.com/writing/kabardian.htm
 Lak,а,a,,Schulze 2007: 3-4.,https://www.omniglot.com/writing/lak.htm
 Lak,аь,aˁ,,Schulze 2007: 3-4.,https://www.omniglot.com/writing/lak.htm
 Lak,б,b,,Schulze 2007: 3-4.,https://www.omniglot.com/writing/lak.htm
@@ -16225,90 +16225,90 @@ Southern Sami,X,h,заимствования,Vangberg 2009,http://www.omniglot.c
 Southern Sami,x,h,заимствования,Vangberg 2009,http://www.omniglot.com/writing/southernsami.htm
 Southern Sami,Z,dz,заимствования,Vangberg 2009,http://www.omniglot.com/writing/southernsami.htm
 Southern Sami,z,dz,заимствования,Vangberg 2009,http://www.omniglot.com/writing/southernsami.htm
-Nothern Sami,A,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,a,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,B,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,b,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,B,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,b,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,C,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,c,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,D,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,d,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,D,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,d,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,E,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,e,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,E,eː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,e,e:,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,F,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,f,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,G,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,g,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,G,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,g,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,H,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,h,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,I,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,i,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,I,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,i,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,I,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,i,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,J,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,j,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,K,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,k,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,K,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,k,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,L,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,l,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,M,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,m,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,N,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,n,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,O,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,o,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,O,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,o,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,P,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,p,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,P,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,p,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,R,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,r,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,S,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,s,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,T,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,t,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,T,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,t,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,T,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,t,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,U,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,u,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,U,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,u,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,V,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,v,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,Ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
-Nothern Sami,ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,A,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,a,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,á,aː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,á,a,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,B,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,b,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,B,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,b,b,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,C,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,c,ts,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,č,t͡ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,D,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,d,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,D,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,d,d,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,đ,ð,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,E,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,e,e,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,E,eː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,e,e:,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,F,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,f,f,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,G,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,g,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,G,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,g,ɡ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,H,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,h,h,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,I,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,i,iː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,I,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,i,i,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,I,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,i,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,J,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,j,j,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,K,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,k,k,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,K,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,k,kʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,L,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,l,l,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,M,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,m,m,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,N,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,n,n,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,ŋ,ŋ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,O,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,o,o,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,O,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,o,oː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,P,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,p,p,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,P,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,p,pʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,R,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,r,r,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,S,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,s,s,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,š,ʃ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,T,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,t,t,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,T,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,t,tʰ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,T,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,t,h(t),,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,ŧ,θ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,U,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,u,u,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,U,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,u,uː,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,V,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,v,v,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,z,dz,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,Ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
+Northern Sami,ž,dʒ,,"Svonni, Mikael 1984",http://www.omniglot.com/writing/northernsami.htm
 Skolt Sami,A,ɑ,,"Korhonen, Mosnikoff, Sammallahti, Pekka 1973.",http://www.omniglot.com/writing/skoltsami.htm
 Skolt Sami,a,ɑ,,"Korhonen, Mosnikoff, Sammallahti, Pekka 1973.",http://www.omniglot.com/writing/skoltsami.htm
 Skolt Sami,Â,ɐ,,"Korhonen, Mosnikoff, Sammallahti, Pekka 1973.",http://www.omniglot.com/writing/skoltsami.htm

--- a/database.csv
+++ b/database.csv
@@ -1700,59 +1700,59 @@ Armenian,Ու,u,,"Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian"
 Armenian,ու,u,,"Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian",http://www.omniglot.com/writing/armenian.htm
 Armenian,Ու,ju,,"Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian",http://www.omniglot.com/writing/armenian.htm
 Armenian,ու,ju,,"Dum-Tragut, Jasmine (2009). Armenian: Modern Eastern Armenian",http://www.omniglot.com/writing/armenian.htm
-Mkhedruli (Georgian),ა,a,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ბ,b,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ბ,pʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),გ,ɡ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),გ,kʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),დ,d,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),დ,tʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ე,ɛ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ვ,v,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ვ,β,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ვ,w,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ვ,f,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ვ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ზ,z,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),თ,tʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ი,ɪ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),კ,kʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ლ,l,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ლ,ɫ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ლ,l̥,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ლ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),მ,m,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ნ,n,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ნ,ŋ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ო,ɔ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),პ,pʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჟ,ʒ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),რ,r,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),რ,ɾ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),რ,r̥,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),რ,ɾ̥,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),რ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ს,s,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ტ,tʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),უ,ʊ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ფ,pʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ქ,kʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ღ,ɣ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ყ,qʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ყ,qχʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ყ,χʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),შ,ʃ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჩ,tʃʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ც,tsʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ძ,dz,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ძ,tsʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),წ,tsʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჭ,tʃʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ხ,x,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჯ,dʒ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჯ,tʃʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჰ,h,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
-Mkhedruli (Georgian),ჰ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ა,a,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ბ,b,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ბ,pʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),გ,ɡ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),გ,kʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),დ,d,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),დ,tʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ე,ɛ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ვ,v,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ვ,β,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ვ,w,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ვ,f,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ვ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ზ,z,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),თ,tʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ი,ɪ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),კ,kʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ლ,l,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ლ,ɫ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ლ,l̥,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ლ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),მ,m,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ნ,n,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ნ,ŋ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ო,ɔ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),პ,pʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჟ,ʒ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),რ,r,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),რ,ɾ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),რ,r̥,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),რ,ɾ̥,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),რ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ს,s,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ტ,tʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),უ,ʊ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ფ,pʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ქ,kʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ღ,ɣ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ყ,qʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ყ,qχʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ყ,χʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),შ,ʃ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჩ,tʃʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ც,tsʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ძ,dz,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ძ,tsʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),წ,tsʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჭ,tʃʼ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ხ,x,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჯ,dʒ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჯ,tʃʰ,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჰ,h,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
+Georgian (Mkhedruli),ჰ,,,"Aronson, Howard I. (1990). Georgian: a reading grammar",http://www.omniglot.com/writing/georgian2.htm
 Hangul (Korean),ㅏ,a,,Lee 1999,http://www.omniglot.com/writing/korean.htm
 Hangul (Korean),ㅏ,aː,,Lee 1999,http://www.omniglot.com/writing/korean.htm
 Hangul (Korean),ᅢ,ε,,Lee 1999,http://www.omniglot.com/writing/korean.htm
@@ -3306,109 +3306,109 @@ Turkish,Y,j,,"Göksel, Kerslake 2005: 4-11",https://www.omniglot.com/writing/tur
 Turkish,y,j,,"Göksel, Kerslake 2005: 4-11",https://www.omniglot.com/writing/turkish.htm
 Turkish,Z,z,,"Göksel, Kerslake 2005: 4-11",https://www.omniglot.com/writing/turkish.htm
 Turkish,z,z,,"Göksel, Kerslake 2005: 4-11",https://www.omniglot.com/writing/turkish.htm
-Nganasan,А,a,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Аа,аː,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ау,аu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,а,a,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,аа,аː,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ау,аu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Б,b,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,б,b,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,В,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,в,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Г,ɡ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,г,ɡ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Д,d,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,д,d,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Е,je,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Еа,ɨa,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,е,je,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,еа,ɨa,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ё,jo,"Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ё,jo,"Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ж,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ж,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,З,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,з,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,З̌,ð,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,з̌,ð,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,И,i,После переднеязычных согласных приобретает характер более заднего звука между гласными И и Ы,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Иа,ia,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Иə,iə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,и,i,После переднеязычных согласных приобретает характер более заднего звука между гласными И и Ы,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,иа,ia,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,иə,iə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Й,j,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,й,j,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,’’,ʔ,"Глухой гортанный смычный. Добавляется к предшествующему звуку, если слово обозначает множественное число",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,К,k,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,к,k,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Л,l,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,л,l,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,М,m,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,м,m,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Н,n,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,н,n,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ӈ,ŋ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ӈ,ŋ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,О,o,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Оу,ou,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,о,o,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,оу,ou,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ө,e,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ө,e,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,П,p,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,п,p,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Р,r,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,р,r,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,С,s,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,с,s,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ç,ç,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ç,ç,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Т,t,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,т,t,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,У,u,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Уа,ua,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Уо,uo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,у,u,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,уа,ua,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,уо,uo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ү,y,Сильно замкнутое У с большим вытягиванием губ,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Үө,ya,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Үо,yo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ү,y,Сильно замкнутое У с большим вытягиванием губ,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,үө,ya,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,үо,yo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ф,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ф,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Х,x,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,х,x,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ц,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ц,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ч,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ч,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ш,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ш,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Щ,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,щ,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ъ,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ъ,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ы,ɨ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ыә,ɨə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ы,ɨ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ыә,ɨə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ь,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ь,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Э,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,э,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ә,ə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Әу,əu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ә,ə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,әу,əu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ю,ju,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,ю,ju,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,Я,ʝ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
-Nganasan,я,ʝ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,А,a,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Аа,аː,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ау,аu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,а,a,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,аа,аː,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ау,аu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Б,b,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,б,b,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,В,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,в,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Г,ɡ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,г,ɡ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Д,d,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,д,d,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Е,je,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Еа,ɨa,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,е,je,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,еа,ɨa,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ё,jo,"Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ё,jo,"Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ж,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ж,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,З,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,з,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,З̌,ð,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,з̌,ð,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,И,i,После переднеязычных согласных приобретает характер более заднего звука между гласными И и Ы,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Иа,ia,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Иə,iə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,и,i,После переднеязычных согласных приобретает характер более заднего звука между гласными И и Ы,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,иа,ia,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,иə,iə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Й,j,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,й,j,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,’’,ʔ,"Глухой гортанный смычный. Добавляется к предшествующему звуку, если слово обозначает множественное число",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,К,k,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,к,k,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Л,l,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,л,l,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,М,m,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,м,m,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Н,n,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,н,n,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ӈ,ŋ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ӈ,ŋ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,О,o,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Оу,ou,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,о,o,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,оу,ou,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ө,e,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ө,e,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,П,p,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,п,p,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Р,r,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,р,r,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,С,s,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,с,s,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ç,ç,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ç,ç,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Т,t,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,т,t,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,У,u,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Уа,ua,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Уо,uo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,у,u,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,уа,ua,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,уо,uo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ү,y,Сильно замкнутое У с большим вытягиванием губ,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Үө,ya,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Үо,yo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ү,y,Сильно замкнутое У с большим вытягиванием губ,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,үө,ya,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,үо,yo,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ф,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ф,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Х,x,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,х,x,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ц,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ц,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ч,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ч,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ш,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ш,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Щ,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,щ,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ъ,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ъ,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ы,ɨ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ыә,ɨə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ы,ɨ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ыә,ɨə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ь,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ь,,"Не обозначает звука, употребляется как и в русском",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Э,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,э,,"Такой звук отсутствует в нганасанском языке. Буква для обозначения этого звука введена в алфавит для правильного написания слов, заимствованных из русского языка",Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ә,ə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Әу,əu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ә,ə,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,әу,əu,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Ю,ju,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,ю,ju,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,Я,ʝ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
+Nganasan 1,я,ʝ,,Zhovnitskaja 2009: 16-27,https://www.omniglot.com/writing/nganasan.htm
 Vietnamese,A,a,,Thompson 1987: 3-17,http://omniglot.com/writing/vietnamese.htm
 Vietnamese,Ach,ɐc,,Thompson 1987: 3-17,http://omniglot.com/writing/vietnamese.htm
 Vietnamese,Anh,ɐɲ,,Thompson 1987: 3-17,http://omniglot.com/writing/vietnamese.htm
@@ -4510,142 +4510,142 @@ Serbian,љ,ʎ,,"Hammond, 2005: 11-30",http://omniglot.com/writing/serbian.htm
 Serbian,њ,ɲ,,"Hammond, 2005: 11-30",http://omniglot.com/writing/serbian.htm
 Serbian,ћ,dʑ,,"Hammond, 2005: 11-30",http://omniglot.com/writing/serbian.htm
 Serbian,џ,tʃ,,"Hammond, 2005: 11-30",http://omniglot.com/writing/serbian.htm
-Tajik,Ё,jɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,А,a,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Б,b,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,В,v,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Г,ɡ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Д,d,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Е,je,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ж,ʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,З,z,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,И,i,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Й,j,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,К,k,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Л,l,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,М,m,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Н,n,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,О,ɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,П,p,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Р,r,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,С,s,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Т,t,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,У,u,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ф,f,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Х,χ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ч,tʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ш,ʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ъ,ɤ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Э,e-,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ю,ju,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Я,ja,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,а,a,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,б,b,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,в,v,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,г,ɡ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,д,d,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,е,je,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ж,ʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,з,z,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,и,i,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,й,j,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,к,k,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,л,l,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,м,m,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,н,n,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,о,ɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,п,p,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,р,r,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,с,s,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,т,t,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,у,u,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ф,f,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,х,χ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ч,tʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ш,ʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ъ,ɤ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,э,e-,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ю,ju,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,я,ja,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ё,jɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ғ,ʁ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ғ,ʁ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Қ,q,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,қ,q,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ҳ,h,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ҳ,h,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ҷ,dʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ҷ,dʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ӣ,ˈi,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ӣ,ˈi,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,Ӯ,ɵ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Tajik,ӯ,ɵ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
-Ukrainian,I,ʲɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,i,ʲɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ï,jɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ï,jɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Є,ʲе,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,А,ɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Б,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,В,w,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Г,ɦ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Д,t,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Е,e,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ж,ʒ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,З,s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,И,i,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Й,i̯,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,К,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Л,l,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,М,m,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Н,n,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,О,ɔ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,П,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Р,r,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,С,z,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Т,d,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,У,ʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ф,v,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Х,x,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ц,t͡s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ч,t͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ш,ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Щ,ʃt͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ь,ʲ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ю,ʲʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Я,ʲɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,а,ɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,б,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,в,w,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,г,ɦ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,д,t,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,е,e,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ж,ʒ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,з,s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,и,i,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,й,i̯,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,к,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,л,l,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,м,m,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,н,n,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,о,ɔ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,п,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,р,r,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,с,z,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,т,d,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,у,ʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ф,v,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,х,x,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ц,t͡s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ч,t͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ш,ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,щ,ʃt͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ь,ʲ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ю,ʲʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,я,ʲɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,є,ʲе,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,Ґ,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
-Ukrainian,ґ,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Tajik 2,Ё,jɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,А,a,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Б,b,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,В,v,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Г,ɡ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Д,d,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Е,je,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ж,ʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,З,z,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,И,i,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Й,j,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,К,k,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Л,l,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,М,m,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Н,n,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,О,ɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,П,p,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Р,r,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,С,s,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Т,t,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,У,u,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ф,f,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Х,χ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ч,tʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ш,ʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ъ,ɤ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Э,e-,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ю,ju,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Я,ja,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,а,a,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,б,b,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,в,v,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,г,ɡ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,д,d,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,е,je,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ж,ʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,з,z,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,и,i,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,й,j,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,к,k,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,л,l,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,м,m,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,н,n,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,о,ɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,п,p,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,р,r,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,с,s,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,т,t,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,у,u,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ф,f,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,х,χ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ч,tʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ш,ʃ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ъ,ɤ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,э,e-,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ю,ju,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,я,ja,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ё,jɔ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ғ,ʁ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ғ,ʁ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Қ,q,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,қ,q,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ҳ,h,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ҳ,h,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ҷ,dʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ҷ,dʒ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ӣ,ˈi,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ӣ,ˈi,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,Ӯ,ɵ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Tajik 2,ӯ,ɵ,,"Ido, 2005: 11-14",http://omniglot.com/writing/tajik.htm
+Ukrainian 1,I,ʲɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,i,ʲɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ï,jɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ï,jɪ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Є,ʲе,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,А,ɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Б,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,В,w,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Г,ɦ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Д,t,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Е,e,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ж,ʒ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,З,s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,И,i,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Й,i̯,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,К,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Л,l,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,М,m,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Н,n,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,О,ɔ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,П,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Р,r,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,С,z,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Т,d,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,У,ʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ф,v,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Х,x,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ц,t͡s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ч,t͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ш,ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Щ,ʃt͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ь,ʲ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ю,ʲʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Я,ʲɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,а,ɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,б,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,в,w,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,г,ɦ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,д,t,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,е,e,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ж,ʒ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,з,s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,и,i,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,й,i̯,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,к,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,л,l,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,м,m,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,н,n,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,о,ɔ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,п,b,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,р,r,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,с,z,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,т,d,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,у,ʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ф,v,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,х,x,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ц,t͡s,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ч,t͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ш,ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,щ,ʃt͡ʃ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ь,ʲ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ю,ʲʊ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,я,ʲɐ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,є,ʲе,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,Ґ,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
+Ukrainian 1,ґ,ɡ,,"Danyenko & Vakylenko, 1995: 3-12",http://omniglot.com/writing/ukrainian.htm
 Uzbek,Ё,jo,,"Ibragimov, 1972: 157-173",http://omniglot.com/writing/uzbek.htm
 Uzbek,Ў,o,,"Ibragimov, 1972: 157-173",http://omniglot.com/writing/uzbek.htm
 Uzbek,А,æ,,"Ibragimov, 1972: 157-173",http://omniglot.com/writing/uzbek.htm
@@ -5895,117 +5895,117 @@ Belarusian 2,Я,ja,,"Comrie, Corbett 1993: 889–893",http://www.omniglot.com/wr
 Belarusian 2,я,ja,,"Comrie, Corbett 1993: 889–893",http://www.omniglot.com/writing/belarusian.htm
 Belarusian 2,я,a,,"Comrie, Corbett 1993: 889–893",http://www.omniglot.com/writing/belarusian.htm
 Belarusian 2,ʼ,no sound,representing [j] after a consonant and before a vowel,"Comrie, Corbett 1993: 889–893",http://www.omniglot.com/writing/belarusian.htm
-Ukrainian,А,a,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,а,a,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Б,b,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Б,bʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,б,b,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,б,bʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,В,w,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,В,wʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,в,w,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,в,wʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Г,ɦ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Г,ɦʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,г,ɦ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,г,ɦʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ґ,ɡ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ґ,ɡ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Д,d,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Д,dʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,д,d,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,д,dʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Е,ɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,е,ɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Є,jɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,є,jɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ж,ʒ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ж,ʒʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ж,ʒ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ж,ʒʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,З,z,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,З,zʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,з,z,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,з,zʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,И,ɪ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,и,ɪ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,I,i,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,i,i,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ї,ji,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ї,ji,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Й,j,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,й,j,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,К,k,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,К,kʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,к,k,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,к,kʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Л,l,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Л,lʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,л,l,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,л,lʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,М,m,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,М,mʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,м,m,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,м,mʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Н,n,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Н,nʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,н,n,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,н,nʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,О,ɔ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,о,ɔ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,П,p,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,П,pʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,п,p,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,п,pʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Р,r,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Р,rʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,р,r,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,р,rʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,С,s,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,С,sʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,с,s,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,с,sʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Т,t,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Т,tʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,т,t,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,т,tʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,У,u,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,у,u,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ф,f,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ф,fʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ф,f,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ф,fʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Х,x,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Х,xʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,х,x,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,х,xʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ц,ts,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ц,tsʲ,"always before [i] and sometimes before [a, ɔ, u]",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ц,ts,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ц,tsʲ,"always before [i] and sometimes before [a, ɔ, u]",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ч,tʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ч,tɕ,before [i] and when lengthened,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ч,tʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ч,tɕ,before [i] and when lengthened,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ш,ʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ш,ʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ш,ʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ш,ʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Щ,ʃtʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Щ,ʃtʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,щ,ʃtʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,щ,ʃtʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ь,no sound,follows the consonants and indicated that they are to be pronounced palatalized,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ь,no sound,follows the consonants and indicated that they are to be pronounced palatalized,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Ю,ju,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ю,ju,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,Я,ja,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,я,ja,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,ʼ,no sound,"separates a consonant, which then remains hard, from a following [j]",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,дж,dʒ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,дж,dʒʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,дз,dz,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
-Ukrainian,дз,dzʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,А,a,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,а,a,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Б,b,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Б,bʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,б,b,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,б,bʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,В,w,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,В,wʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,в,w,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,в,wʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Г,ɦ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Г,ɦʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,г,ɦ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,г,ɦʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ґ,ɡ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ґ,ɡ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Д,d,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Д,dʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,д,d,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,д,dʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Е,ɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,е,ɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Є,jɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,є,jɛ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ж,ʒ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ж,ʒʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ж,ʒ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ж,ʒʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,З,z,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,З,zʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,з,z,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,з,zʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,И,ɪ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,и,ɪ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,I,i,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,i,i,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ї,ji,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ї,ji,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Й,j,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,й,j,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,К,k,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,К,kʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,к,k,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,к,kʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Л,l,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Л,lʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,л,l,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,л,lʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,М,m,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,М,mʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,м,m,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,м,mʲ,"soften slightly before [i], but mostly hard",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Н,n,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Н,nʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,н,n,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,н,nʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,О,ɔ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,о,ɔ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,П,p,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,П,pʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,п,p,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,п,pʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Р,r,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Р,rʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,р,r,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,р,rʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,С,s,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,С,sʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,с,s,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,с,sʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Т,t,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Т,tʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,т,t,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,т,tʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,У,u,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,у,u,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ф,f,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ф,fʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ф,f,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ф,fʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Х,x,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Х,xʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,х,x,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,х,xʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ц,ts,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ц,tsʲ,"always before [i] and sometimes before [a, ɔ, u]",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ц,ts,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ц,tsʲ,"always before [i] and sometimes before [a, ɔ, u]",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ч,tʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ч,tɕ,before [i] and when lengthened,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ч,tʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ч,tɕ,before [i] and when lengthened,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ш,ʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ш,ʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ш,ʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ш,ʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Щ,ʃtʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Щ,ʃtʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,щ,ʃtʃ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,щ,ʃtʃʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ь,no sound,follows the consonants and indicated that they are to be pronounced palatalized,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ь,no sound,follows the consonants and indicated that they are to be pronounced palatalized,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Ю,ju,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ю,ju,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,Я,ja,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,я,ja,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,ʼ,no sound,"separates a consonant, which then remains hard, from a following [j]",Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,дж,dʒ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,дж,dʒʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,дз,dz,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
+Ukrainian 2,дз,dzʲ,,Pugh 1999: 18–32,https://www.omniglot.com/writing/ukrainian.htm
 Bulgarian 2,А,a,,"Comrie, Corbett 1993: 190–192",https://www.omniglot.com/writing/bulgarian.htm
 Bulgarian 2,а,a,,"Comrie, Corbett 1993: 190–192",https://www.omniglot.com/writing/bulgarian.htm
 Bulgarian 2,Б,b,,"Comrie, Corbett 1993: 190–192",https://www.omniglot.com/writing/bulgarian.htm
@@ -6873,213 +6873,213 @@ Lower Sorbian,ž,ʒ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com
 Lower Sorbian,ž,ʃ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
 Lower Sorbian,Ź,ʑ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
 Lower Sorbian,ź,ʑ,,"Comrie, Corbett 1993: 605–607",https://www.omniglot.com/writing/sorbian.htm
-Persian,ـئ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian, ـؤ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـأ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـئـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ئـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian, أ,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ء,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـا,ɒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,آ ,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian, ا,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـب,b,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـبـ,b,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,بـ,b,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ب,b,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـپ,p,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـپـ,p,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,پـ,p,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,پ,p,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـت,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـتـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,تـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ت,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـث,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـثـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ثـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ث,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـج,d͡ʒ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـجـ,d͡ʒ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,جـ,d͡ʒ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ج,d͡ʒ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـچ,t͡ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـچـ,t͡ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,چـ,t͡ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,چ,t͡ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـح,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـحـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,حـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ح,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـخ,x,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـخـ,x,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,خـ,x,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,خ,x,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـد,d,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,د,d,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـذ,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ذ,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـر,ɾ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ر,ɾ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـز,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ز,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـژ,ʒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ژ,ʒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـس,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـسـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,سـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,س,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـش,ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـشـ,ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,شـ,ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ش,ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـص,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـصـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,صـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ص,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـض,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـضـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ضـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ض,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـط,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـطـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,طـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ط,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـظ,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـظـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ظـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ظ,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـع,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـعـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,عـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ع,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـغ,ɣ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـغـ,ɣ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,غـ,ɣ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,غ,ɣ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـف,f,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـفـ,f,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,فـ,f,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ف,f,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـق,ɢ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـقـ,ɢ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,قـ,ɢ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ق,ɢ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـک,k,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـکـ,k,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,کـ,k,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ک,k,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـگ,ɡ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـگـ,ɡ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,گـ,ɡ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,گ,ɡ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـل,l,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـلـ,l,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,لـ,l,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ل,l,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـم,m,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـمـ,m,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,مـ,m,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,م,m,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـن,n,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـنـ,n,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,نـ,n,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ن,n,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـو,v,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـو,ow,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـو,u,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـو,o,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,و,v,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,و,u,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,و,ow,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـه,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـه,e,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـه,a,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـهـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,هـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ه,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـی,y,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـی,i,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـی,ey,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـیـ,y,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـیـ,i,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ـیـ,ey,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,یـ,y,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,یـ,i,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,یـ,ey,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ی,y,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ی,i,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Persian,ی,ey,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
-Tadjik,А,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,а,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Б,b,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,б,b,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,В,v,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,в,v,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Г,ɡ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,г,ɡ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ғ,ʁ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ғ,ʁ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Д,d,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,д,d,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Е,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,е,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ё,jɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ё,jɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ж,ʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ж,ʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,З,z,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,з,z,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,И,i,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,и,i,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Й,j,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,й,j,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ӣ,ʲi,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ӣ,ʲi,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,К,k,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,к,k,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Қ,q,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,қ,q,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Л,l,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,л,l,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,М,m,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,м,m,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Н,n,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,н,n,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,О,ɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,о,ɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,П,p,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,п,p,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Р,ɾ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,р,ɾ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,С,s,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,с,s,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Т,t,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,т,t,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,У,u,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,у,u,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ӯ,ɵ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ӯ,ɵ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ф,f,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ф,f,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Х,x,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,х,x,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ҳ,h,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ҳ,h,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ч,tʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ч,tʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ҷ,dʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ҷ,dʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ш,ʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ш,ʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ъ,ʔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ъ,ʔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Э,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,э,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Ю,ju,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,ю,ju,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,Я,ja,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
-Tadjik,я,ja,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Persian 1,ـئ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1, ـؤ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـأ,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـئـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ئـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1, أ,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ء,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـا,ɒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,آ ,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1, ا,ɒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـب,b,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـبـ,b,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,بـ,b,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ب,b,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـپ,p,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـپـ,p,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,پـ,p,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,پ,p,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـت,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـتـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,تـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ت,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـث,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـثـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ثـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ث,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـج,d͡ʒ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـجـ,d͡ʒ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,جـ,d͡ʒ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ج,d͡ʒ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـچ,t͡ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـچـ,t͡ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,چـ,t͡ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,چ,t͡ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـح,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـحـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,حـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ح,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـخ,x,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـخـ,x,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,خـ,x,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,خ,x,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـد,d,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,د,d,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـذ,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ذ,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـر,ɾ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ر,ɾ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـز,z,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ز,z,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـژ,ʒ,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ژ,ʒ,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـس,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـسـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,سـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,س,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـش,ʃ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـشـ,ʃ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,شـ,ʃ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ش,ʃ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـص,s,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـصـ,s,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,صـ,s,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ص,s,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـض,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـضـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ضـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ض,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـط,t,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـطـ,t,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,طـ,t,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ط,t,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـظ,z,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـظـ,z,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ظـ,z,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ظ,z,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـع,ʔ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـعـ,ʔ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,عـ,ʔ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ع,ʔ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـغ,ɣ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـغـ,ɣ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,غـ,ɣ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,غ,ɣ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـف,f,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـفـ,f,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,فـ,f,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ف,f,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـق,ɢ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـقـ,ɢ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,قـ,ɢ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ق,ɢ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـک,k,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـکـ,k,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,کـ,k,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ک,k,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـگ,ɡ,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـگـ,ɡ,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,گـ,ɡ,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,گ,ɡ,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـل,l,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـلـ,l,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,لـ,l,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ل,l,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـم,m,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـمـ,m,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,مـ,m,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,م,m,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـن,n,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـنـ,n,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,نـ,n,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ن,n,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـو,v,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـو,ow,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـو,u,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـو,o,Final/Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,و,v,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,و,u,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,و,ow,Initial/Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـه,h,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـه,e,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـه,a,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـهـ,h,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,هـ,h,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ه,h,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـی,y,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـی,i,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـی,ey,Final,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـیـ,y,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـیـ,i,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ـیـ,ey,Medial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,یـ,y,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,یـ,i,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,یـ,ey,Initial,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ی,y,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ی,i,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Persian 1,ی,ey,Isolated,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/persian.htm
+Tajik 1,А,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,а,a,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Б,b,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,б,b,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,В,v,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,в,v,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Г,ɡ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,г,ɡ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ғ,ʁ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ғ,ʁ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Д,d,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,д,d,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Е,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,е,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ё,jɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ё,jɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ж,ʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ж,ʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,З,z,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,з,z,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,И,i,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,и,i,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Й,j,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,й,j,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ӣ,ʲi,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ӣ,ʲi,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,К,k,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,к,k,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Қ,q,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,қ,q,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Л,l,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,л,l,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,М,m,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,м,m,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Н,n,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,н,n,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,О,ɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,о,ɔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,П,p,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,п,p,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Р,ɾ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,р,ɾ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,С,s,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,с,s,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Т,t,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,т,t,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,У,u,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,у,u,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ӯ,ɵ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ӯ,ɵ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ф,f,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ф,f,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Х,x,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,х,x,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ҳ,h,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ҳ,h,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ч,tʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ч,tʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ҷ,dʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ҷ,dʒ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ш,ʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ш,ʃ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ъ,ʔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ъ,ʔ,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Э,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,э,e,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Ю,ju,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,ю,ju,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,Я,ja,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
+Tajik 1,я,ja,,"Perry, J. R., & Windfuhr, G. (2013)",https://www.omniglot.com/writing/tajik.htm
 Maori,A,a,,"Williams, W. L. (1862)",https://www.omniglot.com/writing/maori.htm
 Maori,A,ʌ,,"Williams, W. L. (1862)",https://www.omniglot.com/writing/maori.htm
 Maori,a,a,,"Williams, W. L. (1862)",https://www.omniglot.com/writing/maori.htm
@@ -8187,163 +8187,163 @@ Pashto,ئـ,əi,initial,Lehr 2014,http://www.omniglot.com/writing/pashto.htm
 Pashto,ئـ,j,initial,Lehr 2014,http://www.omniglot.com/writing/pashto.htm
 Pashto,ـئـ,əi,medial,Lehr 2014,http://www.omniglot.com/writing/pashto.htm
 Pashto,ـئـ,j,medial,Lehr 2014,http://www.omniglot.com/writing/pashto.htm
-Persian,ـئ,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـؤ,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـأ,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـئـ,ʔ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ئـ,ʔ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,أ,ʔ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ء,ʔ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـا,ɒ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـا,ɒ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,آ,ɒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ا,ɒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,آ,ɒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ا,ɒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـب,b,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـبـ,b,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,بـ,b,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ب,b,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـپ,p,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـپـ,p,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,پـ,p,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,پ,p,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـت,t,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـتـ,t,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,تـ,t,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ت,t,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـث,s,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـثـ,s,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ثـ,s,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ث,s,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـج,d͡ʒ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـجـ,d͡ʒ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,جـ,d͡ʒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ج,d͡ʒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـچ,t͡ʃ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـچـ,t͡ʃ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,چـ,t͡ʃ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,چ,t͡ʃ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـح,h,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـحـ,h,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,حـ,h,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ح,h,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـخ,x,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـخـ,x,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,خـ,x,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,خ,x,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـد,d,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـد,d,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,د,d,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,د,d,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـذ,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـذ,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ذ,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ذ,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـر,ɾ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـر,ɾ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ر,ɾ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ر,ɾ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـز,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـز,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ز,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ز,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـژ,ʒ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـژ,ʒ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ژ,ʒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ژ,ʒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـس,s,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـسـ,s,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,سـ,s,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,س,s,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـش,ʃ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـشـ,ʃ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,شـ,ʃ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ش,ʃ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـص,s,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـصـ,s,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,صـ,s,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ص,s,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـض,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـضـ,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ضـ,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ض,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـط,t,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـطـ,t,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,طـ,t,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ط,t,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـظ,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـظـ,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ظـ,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ظ,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـع,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـعـ,ʔ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,عـ,ʔ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ع,ʔ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـغ,ɣ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـغـ,ɣ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,غـ,ɣ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,غ,ɣ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـف,f,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـفـ,f,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,فـ,f,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ف,f,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـق,ɢ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـقـ,ɢ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,قـ,ɢ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ق,ɢ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـک,k,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـکـ,k,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,کـ,k,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ک,k,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـگ,ɡ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـگـ,ɡ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,گـ,ɡ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,گ,ɡ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـل,l,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـلـ,l,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,لـ,l,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ل,l,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـم,m,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـمـ,m,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,مـ,m,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,م,m,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـن,n,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـنـ,n,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,نـ,n,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ن,n,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,v,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,u,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,ow,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,o,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,v,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,u,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,ow,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـو,o,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,و,v,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,و,u,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,و,ow,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,و,v,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,و,u,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,و,ow,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـه,h,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـه,e,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـه,a,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـهـ,h,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,هـ,h,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ه,h,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـی,y,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـی,i,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـی,ey,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـیـ,y,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـیـ,i,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ـیـ,ey,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,یـ,y,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,یـ,i,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,یـ,ey,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ی,y,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ی,i,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
-Persian,ی,ey,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـئ,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـؤ,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـأ,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـئـ,ʔ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ئـ,ʔ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,أ,ʔ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ء,ʔ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـا,ɒ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـا,ɒ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,آ,ɒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ا,ɒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,آ,ɒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ا,ɒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـب,b,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـبـ,b,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,بـ,b,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ب,b,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـپ,p,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـپـ,p,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,پـ,p,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,پ,p,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـت,t,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـتـ,t,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,تـ,t,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ت,t,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـث,s,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـثـ,s,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ثـ,s,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ث,s,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـج,d͡ʒ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـجـ,d͡ʒ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,جـ,d͡ʒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ج,d͡ʒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـچ,t͡ʃ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـچـ,t͡ʃ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,چـ,t͡ʃ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,چ,t͡ʃ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـح,h,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـحـ,h,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,حـ,h,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ح,h,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـخ,x,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـخـ,x,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,خـ,x,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,خ,x,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـد,d,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـد,d,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,د,d,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,د,d,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـذ,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـذ,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ذ,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ذ,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـر,ɾ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـر,ɾ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ر,ɾ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ر,ɾ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـز,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـز,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ز,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ز,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـژ,ʒ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـژ,ʒ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ژ,ʒ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ژ,ʒ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـس,s,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـسـ,s,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,سـ,s,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,س,s,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـش,ʃ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـشـ,ʃ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,شـ,ʃ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ش,ʃ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـص,s,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـصـ,s,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,صـ,s,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ص,s,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـض,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـضـ,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ضـ,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ض,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـط,t,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـطـ,t,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,طـ,t,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ط,t,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـظ,z,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـظـ,z,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ظـ,z,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ظ,z,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـع,ʔ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـعـ,ʔ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,عـ,ʔ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ع,ʔ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـغ,ɣ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـغـ,ɣ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,غـ,ɣ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,غ,ɣ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـف,f,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـفـ,f,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,فـ,f,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ف,f,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـق,ɢ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـقـ,ɢ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,قـ,ɢ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ق,ɢ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـک,k,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـکـ,k,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,کـ,k,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ک,k,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـگ,ɡ,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـگـ,ɡ,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,گـ,ɡ,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,گ,ɡ,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـل,l,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـلـ,l,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,لـ,l,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ل,l,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـم,m,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـمـ,m,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,مـ,m,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,م,m,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـن,n,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـنـ,n,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,نـ,n,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ن,n,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,v,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,u,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,ow,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,o,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,v,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,u,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,ow,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـو,o,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,و,v,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,و,u,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,و,ow,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,و,v,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,و,u,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,و,ow,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـه,h,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـه,e,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـه,a,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـهـ,h,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,هـ,h,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ه,h,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـی,y,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـی,i,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـی,ey,Final,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـیـ,y,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـیـ,i,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ـیـ,ey,Medial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,یـ,y,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,یـ,i,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,یـ,ey,Initial,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ی,y,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ی,i,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
+Persian 2,ی,ey,Isolated,"Perry, Windfuhr 2013: 492-620",http://www.omniglot.com/writing/persian.htm
 Arabic,ء,ʔ,isolated,Ryding 2005,http://www.omniglot.com/writing/arabic.htm
 Arabic,ء,ʔ,final,Ryding 2005,http://www.omniglot.com/writing/arabic.htm
 Arabic,ئ,ʔ,initial,Ryding 2005,http://www.omniglot.com/writing/arabic.htm
@@ -9045,235 +9045,235 @@ Kurdish,ﺯ,z,isolated,McCarus 2013: 663-709,http://www.omniglot.com/writing/kur
 Kurdish,ـز,z,final,McCarus 2013: 663-709,http://www.omniglot.com/writing/kurdish.htm
 Kurdish,-,,initial,McCarus 2013: 663-709,http://www.omniglot.com/writing/kurdish.htm
 Kurdish,-,,medial,McCarus 2013: 663-709,http://www.omniglot.com/writing/kurdish.htm
-Somali Abjad,ﺍ,ʔ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـا,ʔ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺍ,ʔ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـا,ʔ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺍ,a,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـا,a,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺍ,a,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـا,a,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺍ,æ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـا,æ:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺍ,æ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـا,æ:,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ب,b,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـب,b,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,بـ,b,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـبـ,b,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ت,t,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـت,t,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,تـ,t,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـتـ,t,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺝ,tʃ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـج,tʃ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,جـ,tʃ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـجـ,tʃ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺡ,ħ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـح,ħ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,حـ,ħ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـحـ,ħ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺥ,χ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـخ,χ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,خـ,χ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـخـ,χ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺩ,d,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـد,d,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺩ,d,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـد,d,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺭ,r,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـر,r,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺭ,r,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـر,r,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺱ,s,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـس,s,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,سـ,s,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـسـ,s,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﺵ,ʃ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـش,ʃ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,شـ,ʃ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـشـ,ʃ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ط,ɖ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـط,ɖ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,طـ,ɖ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـطـ,ɖ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻊ,ʕ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻉ,ʕ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻌ,ʕ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻋ,ʕ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻎ,ɡ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻍ,ɡ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻐ,ɡ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻏ,ɡ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻑ,f,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻑ,f,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻔ,f,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻓ,f,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻕ,ɢ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻕ,ɢ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻘ,ɢ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻗ,ɢ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻙ,k,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻙ,k,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻜ,k,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻛ,k,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻝ,l,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻝ,l,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻠ,l,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻟ,l,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻡ,m,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻡ,m,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻤ,m,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻣ,m,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻥ,n,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻥ,n,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻨ,n,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻨ,n,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,w,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـو,w,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,وٓ,u:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,وٓ,u:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,ʉ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ـو,ʉ:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻩ,h,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻬ,h,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻫ,h,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻪ,h,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,ʉ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,u,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,ʉ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,u,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,ʉ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,u,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,ʉ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻭ,u,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻲ,j,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻲ,i:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻲ,ɪ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻱ,j,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻱ,i:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻱ,ɪ:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻴ,j,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻴ,i:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻴ,ɪ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻳ,j,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻳ,i:,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ﻳ,ɪ:,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,أى,e,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,أى,ɛ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ى,i,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ى,ɪ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ىٓ,i:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ىٓ,ɪ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ؤ,ɞ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,ؤ,ɔ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,أو,ɞ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,أو,ɔ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,آ,æ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,آ,ɑ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,آ,æ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,آ,ɑ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Abjad,-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,A,æ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,A,æ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,a,ɑ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,a,ɑ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Aa,æ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Aa,ɑ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,aa,æ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,aa,ɑ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,B,b,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,b,b,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,C,ʕ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,c,ʕ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,D,d,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,d,d,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Dh,ɖ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,dh,ɖ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,E,e,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,e,e,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,E,ɛ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,e,ɛ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Ee,ɛ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,ee,e:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Ee,ɛ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,ee,e:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,F,f,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,f,f,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,G,ɡ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,g,ɡ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,H,h,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,h,h,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,I,i,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,I,ɪ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,i,i,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,i,ɪ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Ii,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,ii,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Ii,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,ii,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,J,tʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,j,tʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,K,k,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,k,k,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Kh,χ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,kh,χ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,L,l,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,l,l,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,M,m,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,m,m,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,N,n,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,n,n,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,O,ɞ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,O,ɔ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,o,ɞ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,o,ɔ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Oo,ɞ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Oo,ɔ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,oo,ɞ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,oo,ɔ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Q,ɢ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,q,ɢ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,R,r,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,r,r,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,S,s,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,s,s,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Sh,ʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,sh,ʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,T,t,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,t,t,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,U,ʉ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,U,u,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,u,ʉ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,u,u,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Uu,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,uu,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Uu,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,uu,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,W,w,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,W,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,W,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,w,w,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,w,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,w,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,X,ħ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,x,ħ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Y,j,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Y,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,Y,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,y,j,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,y,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,y,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
-Somali Latin,,ʔ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺍ,ʔ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـا,ʔ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺍ,ʔ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـا,ʔ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺍ,a,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـا,a,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺍ,a,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـا,a,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺍ,æ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـا,æ:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺍ,æ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـا,æ:,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ب,b,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـب,b,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),بـ,b,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـبـ,b,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ت,t,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـت,t,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),تـ,t,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـتـ,t,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺝ,tʃ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـج,tʃ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),جـ,tʃ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـجـ,tʃ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺡ,ħ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـح,ħ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),حـ,ħ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـحـ,ħ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺥ,χ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـخ,χ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),خـ,χ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـخـ,χ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺩ,d,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـد,d,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺩ,d,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـد,d,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺭ,r,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـر,r,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺭ,r,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـر,r,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺱ,s,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـس,s,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),سـ,s,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـسـ,s,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﺵ,ʃ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـش,ʃ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),شـ,ʃ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـشـ,ʃ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ط,ɖ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـط,ɖ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),طـ,ɖ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـطـ,ɖ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻊ,ʕ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻉ,ʕ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻌ,ʕ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻋ,ʕ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻎ,ɡ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻍ,ɡ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻐ,ɡ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻏ,ɡ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻑ,f,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻑ,f,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻔ,f,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻓ,f,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻕ,ɢ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻕ,ɢ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻘ,ɢ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻗ,ɢ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻙ,k,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻙ,k,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻜ,k,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻛ,k,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻝ,l,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻝ,l,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻠ,l,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻟ,l,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻡ,m,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻡ,m,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻤ,m,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻣ,m,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻥ,n,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻥ,n,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻨ,n,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻨ,n,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,w,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـو,w,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),وٓ,u:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),وٓ,u:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,ʉ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ـو,ʉ:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻩ,h,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻬ,h,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻫ,h,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻪ,h,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,ʉ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,u,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,ʉ,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,u,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,ʉ,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,u,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,ʉ,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻭ,u,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻲ,j,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻲ,i:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻲ,ɪ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻱ,j,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻱ,i:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻱ,ɪ:,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻴ,j,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻴ,i:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻴ,ɪ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻳ,j,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻳ,i:,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ﻳ,ɪ:,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),أى,e,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),أى,ɛ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ى,i,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ى,ɪ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ىٓ,i:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ىٓ,ɪ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ؤ,ɞ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),ؤ,ɔ,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),أو,ɞ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),أو,ɔ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),آ,æ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),آ,ɑ:,isolated,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,final,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),آ,æ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),آ,ɑ:,initial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Abjad),-,,medial,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),A,æ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),A,æ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),a,ɑ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),a,ɑ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Aa,æ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Aa,ɑ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),aa,æ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),aa,ɑ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),B,b,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),b,b,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),C,ʕ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),c,ʕ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),D,d,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),d,d,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Dh,ɖ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),dh,ɖ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),E,e,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),e,e,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),E,ɛ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),e,ɛ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Ee,ɛ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),ee,e:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Ee,ɛ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),ee,e:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),F,f,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),f,f,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),G,ɡ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),g,ɡ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),H,h,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),h,h,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),I,i,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),I,ɪ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),i,i,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),i,ɪ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Ii,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),ii,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Ii,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),ii,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),J,tʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),j,tʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),K,k,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),k,k,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Kh,χ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),kh,χ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),L,l,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),l,l,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),M,m,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),m,m,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),N,n,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),n,n,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),O,ɞ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),O,ɔ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),o,ɞ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),o,ɔ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Oo,ɞ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Oo,ɔ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),oo,ɞ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),oo,ɔ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Q,ɢ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),q,ɢ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),R,r,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),r,r,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),S,s,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),s,s,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Sh,ʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),sh,ʃ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),T,t,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),t,t,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),U,ʉ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),U,u,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),u,ʉ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),u,u,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Uu,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),uu,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Uu,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),uu,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),W,w,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),W,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),W,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),w,w,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),w,ʉ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),w,u:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),X,ħ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),x,ħ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Y,j,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Y,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),Y,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),y,j,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),y,i:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),y,ɪ:,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
+Somali (Latin),,ʔ,,Saeed 1999,http://www.omniglot.com/writing/somali.htm
 Comorian,ﺍ,ʔ,isolated,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
 Comorian,ﺍ,aː,isolated,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
 Comorian,ﺍ,i,isolated,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
@@ -9427,209 +9427,209 @@ Comorian,ُ,o,,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
 Comorian,ِ,i,,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
 Comorian,ِ,e,,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
 Comorian,َ,a,,Mohamed 2001,http://www.omniglot.com/writing/comorian.htm
-Tigre Geez,ሀ,hä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሁ,hu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሂ,hi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሃ,ha,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሄ,he,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ህ,h(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሆ,ho,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ለ,lä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሉ,lu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሊ,li,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ላ,la,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሌ,le,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ል,l(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሎ,lo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሏ,wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሐ,ħ,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሑ,ħu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሒ,ħi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሓ,ħä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሔ,ħe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሕ,ħ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሖ,ħo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,መ,mä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሙ,mu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሚ,mi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ማ,ma,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሜ,me,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ም,m(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሞ,mo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ረ,rä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሩ,ru,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሪ,ri,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ራ,ra,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሬ,re,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ር,r(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሮ,ro,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሰ,sä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሱ,su,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሲ,si,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሳ,sa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሴ,se,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ስ,s(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ሶ,so,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቀ,k'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቁ,k'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቂ,k'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቃ,k'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቄ,k'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቅ,k'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቆ,k'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,በ,bä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቡ,bu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቢ,bi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ባ,ba,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቤ,be,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ብ,b(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቦ,bo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ተ,tä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቱ,tu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቲ,ti,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ታ,ta,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቴ,te,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ት,t(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቶ,to,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቸ,tʃä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቹ,tʃu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቺ,tʃi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቻ,tʃa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቼ,tʃe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ች,tʃ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቾ,tʃo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኀ,χä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኁ,χu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኂ,χi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኃ,χa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኄ,χe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኅ,χ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኆ,χo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ነ,nä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኑ,nu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኒ,ni,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ና,,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኔ,ne,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ን,n(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኖ,no,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,አ,ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኡ,u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኢ,i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኣ,a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኤ,e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,እ,(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኦ,o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኧ,ka,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ከ,ku,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኩ,ki,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኪ,ka,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ካ,ke,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኬ,k(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ክ,ko,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ወ,wä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዉ,wu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዊ,wi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዋ,wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዌ,we,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ው,w(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዎ,wo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዐ,ʕä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዑ,ʕu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዒ,ʕi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዓ,ʕa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዔ,ʕe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዕ,ʕ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዖ,ʕo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዘ,zä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዙ,zu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዚ,zi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዛ,za,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዜ,ze,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዝ,z(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዞ,zo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዠ,ʒä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዡ,ʒu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዢ,ʒi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዣ,ʒa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዤ,ʒe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዥ,ʒ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዦ,ʒo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,የ,jä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዩ,ju,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዪ,ji,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ያ,ja,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዬ,je,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ይ,j(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዮ,jo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ደ,dä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዱ,du,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዲ,di,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዳ,da,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዴ,de,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ድ,d(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ዶ,do,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ገ,ɡä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጉ,ɡu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጊ,ɡi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጋ,ɡa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጌ,ɡe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ግ,ɡ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጎ,ɡo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጠ,t'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጡ,t'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጢ,t'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጣ,t'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጤ,t'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጥ,t'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጦ,t'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጰ,p'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጱ,p'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጲ,p'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጳ,p'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጴ,p'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጵ,p'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጶ,p'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጸ,s'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጹ,s'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጺ,s'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጻ,s'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጼ,s'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጽ,s'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጾ,s'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፈ,fä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፉ,fu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፊ,fi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፋ,fa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፌ,fe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፍ,f(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፎ,fo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፐ,pä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፑ,pu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፒ,pi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፓ,pa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፔ,pe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፕ,p(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ፖ,po,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቈ,k'wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቊ,k'wi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቋ,k'wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቌ,k'we,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ቍ,k'w(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኈ,xwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኊ,xwi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኋ,xwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኌ,xwe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኍ,xw(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኰ,kwä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኲ,kwi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኳ,kwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኴ,ke,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ኵ,kw(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጐ,ɡwä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጒ,ɡwi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጓ,ɡwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጔ,ɡwe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Geez,ጕ,ɡw(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሀ,hä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሁ,hu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሂ,hi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሃ,ha,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሄ,he,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ህ,h(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሆ,ho,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ለ,lä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሉ,lu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሊ,li,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ላ,la,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሌ,le,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ል,l(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሎ,lo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሏ,wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሐ,ħ,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሑ,ħu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሒ,ħi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሓ,ħä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሔ,ħe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሕ,ħ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሖ,ħo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),መ,mä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሙ,mu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሚ,mi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ማ,ma,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሜ,me,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ም,m(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሞ,mo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ረ,rä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሩ,ru,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሪ,ri,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ራ,ra,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሬ,re,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ር,r(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሮ,ro,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሰ,sä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሱ,su,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሲ,si,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሳ,sa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሴ,se,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ስ,s(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ሶ,so,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቀ,k'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቁ,k'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቂ,k'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቃ,k'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቄ,k'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቅ,k'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቆ,k'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),በ,bä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቡ,bu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቢ,bi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ባ,ba,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቤ,be,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ብ,b(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቦ,bo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ተ,tä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቱ,tu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቲ,ti,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ታ,ta,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቴ,te,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ት,t(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቶ,to,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቸ,tʃä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቹ,tʃu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቺ,tʃi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቻ,tʃa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቼ,tʃe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ች,tʃ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቾ,tʃo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኀ,χä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኁ,χu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኂ,χi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኃ,χa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኄ,χe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኅ,χ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኆ,χo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ነ,nä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኑ,nu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኒ,ni,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ና,,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኔ,ne,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ን,n(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኖ,no,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),አ,ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኡ,u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኢ,i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኣ,a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኤ,e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),እ,(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኦ,o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኧ,ka,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ከ,ku,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኩ,ki,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኪ,ka,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ካ,ke,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኬ,k(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ክ,ko,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ወ,wä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዉ,wu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዊ,wi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዋ,wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዌ,we,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ው,w(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዎ,wo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዐ,ʕä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዑ,ʕu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዒ,ʕi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዓ,ʕa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዔ,ʕe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዕ,ʕ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዖ,ʕo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዘ,zä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዙ,zu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዚ,zi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዛ,za,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዜ,ze,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዝ,z(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዞ,zo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዠ,ʒä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዡ,ʒu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዢ,ʒi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዣ,ʒa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዤ,ʒe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዥ,ʒ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዦ,ʒo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),የ,jä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዩ,ju,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዪ,ji,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ያ,ja,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዬ,je,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ይ,j(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዮ,jo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ደ,dä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዱ,du,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዲ,di,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዳ,da,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዴ,de,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ድ,d(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ዶ,do,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ገ,ɡä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጉ,ɡu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጊ,ɡi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጋ,ɡa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጌ,ɡe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ግ,ɡ(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጎ,ɡo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጠ,t'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጡ,t'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጢ,t'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጣ,t'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጤ,t'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጥ,t'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጦ,t'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጰ,p'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጱ,p'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጲ,p'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጳ,p'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጴ,p'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጵ,p'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጶ,p'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጸ,s'ä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጹ,s'u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጺ,s'i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጻ,s'a,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጼ,s'e,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጽ,s'(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጾ,s'o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፈ,fä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፉ,fu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፊ,fi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፋ,fa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፌ,fe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፍ,f(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፎ,fo,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፐ,pä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፑ,pu,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፒ,pi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፓ,pa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፔ,pe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፕ,p(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ፖ,po,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቈ,k'wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቊ,k'wi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቋ,k'wa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቌ,k'we,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ቍ,k'w(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኈ,xwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኊ,xwi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኋ,xwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኌ,xwe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኍ,xw(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኰ,kwä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኲ,kwi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኳ,kwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኴ,ke,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ኵ,kw(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጐ,ɡwä,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጒ,ɡwi,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጓ,ɡwa,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጔ,ɡwe,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Geez),ጕ,ɡw(ə),,Raz 1983,http://www.omniglot.com/writing/tigre.htm
 Tigrinya,ሀ,hä,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
 Tigrinya,ሁ,hu,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
 Tigrinya,ሂ,hi,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
@@ -9842,289 +9842,289 @@ Tigrinya,ኸ,x,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
 Tigrinya,ዀ,xw,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
 Tigrinya,ጀ,ʤ,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
 Tigrinya,ጨ,ʧʼ,,Mason 1996,http://www.omniglot.com/writing/tigrinya.htm
-Tigre Abjad,آ,ʔ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ا,∅,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـا,ʔ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـا,∅,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,آ,∅,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ا,ʔ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـا,∅,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـا,ʔ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ب,b,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـب,b,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,بـ,b,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـبـ,b,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,پ,p,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـپ,p,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,پـ,p,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـپـ,p,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ت,t̪,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـت,t̪,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,تـ,t̪,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـتـ,t̪,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ث,s,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـث,s,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ثـ,s,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـثـ,s,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ج,d͡ʒ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـج,d͡ʒ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,جـ,d͡ʒ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـجـ,d͡ʒ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ح,ħ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـح,ħ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,حـ,ħ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـحـ,ħ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,خ,x,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـخ,x,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,خـ,x,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـخـ,x,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,د,d̪,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـد,d̪,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,د,d̪,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـد,d̪,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ذ,z,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـذ,z,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ذ,z,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـذ,z,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ر,r,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـر,r,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ر,r,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـر,r,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ز,z,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـز,z,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ز,z,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـز,z,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ژ,ʒ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـژ,ʒ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,-,,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,-,,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,س,s,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـس,s,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,سـ,s,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـسـ,s,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ش,ʃ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـش,ʃ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,شـ,ʃ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـشـ,ʃ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ڛ,tʃ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,‍ڛ,tʃ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ڛ‍,tʃ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,‍ڛ‍,tʃ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ص,s',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـص,s',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,صـ,s',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـصـ,s',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ض,d,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـض,d,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ضـ,d,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـضـ,d,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ط,t',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـط,t',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,طـ,t',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـطـ,t',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ظ,z,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـظ,z,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ظـ,z,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـظـ,z,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ڟ,tʃ’,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـڟ,tʃ’,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ڟـ,tʃ’,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـڟـ,tʃ’,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ع,ʕ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـع,ʕ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,عـ,ʕ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـعـ,ʕ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,غ,ɡ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـغ,ɡ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,غـ,ɡ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـغـ,ɡ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ف,f,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـف,f,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,فـ,f,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـفـ,f,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ڥ,p',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـڥ,p',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـڥـ,p',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ڥـ,p',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ق,k',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـق,k',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,قـ,k',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـقـ,k',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ك,k,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـ‍ك‎,k,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,كـ‍,k,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـ‍ك‍ـ,k,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ل,l,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـل,l,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,لـ,l,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـلـ,l,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,م,m,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـم,m,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,مـ,m,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـمـ,m,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ن,n,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـن,n,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,نـ,n,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـنـ,n,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,و,w,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,و,w,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,و,w,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,-,,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ه,h,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـه,h,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,هـ,h,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـهـ,h,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ي,j,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـي,j,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,يـ,j,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ـيـ,j,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ِي,e,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ِـي,e,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ِيـ,e,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ِـيـ,e,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ُو,o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,"آ, َا",a:,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ْ,ɨ,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ْ,∅,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ُ,u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,ِ,i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Tigre Abjad,َ,ɐ,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
-Ainu Latin,a,a,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,i,i,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,u,ɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,e,e,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,o,o,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ka,ka,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ki,kʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ku,kɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ke,ke,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ko,ko,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,sa,ʃa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,si,ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,su,sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,se,se,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,so,so,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ta,ta,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ci,t͡ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,tu,t͡sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,te,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,to,to,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,,,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ni,ɲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,nu,nɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ne,ne,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,no,no,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ha,ha,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,hi,çi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,hu,ɸɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,he,he,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ho,ho,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ma,ma,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,mi,mʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,mu,mɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,me,me,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,mo,mo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ya,ja,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,yu,jɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ye,je,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,yo,jo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ra,ɾa],,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ri,ɾʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ru,ɾɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,re,ɾe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ro,ɾo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,wa,ɰa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,we,ɰe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,wo,ɰo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,n,/N/,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,pa,pa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,pi,pʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,pu,pɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,pe,pe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,po,po,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ca,t͡ɕʲa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,cu,t͡ɕʲɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Latin,ce,t͡ɕʲo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ア,a,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,イ,i,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ウ,u,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,エ,e,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,オ,o,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,カ,ka,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,キ,kʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ク,ku,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ケ,ke,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,コ,ko,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,サ,ʃa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,シ,ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ス,sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,セ,se,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ソ,so,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,タ,ta,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,チ,t͡ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,トゥ,t͡sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,テ,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ト,to,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ナ,,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ニ,ɲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ヌ,nu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ネ,ne,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ノ,no,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ハ,ha,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ヒ,çi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,フ,ɸu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ヘ,he,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ホ,ho,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,マ,ma,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ミ,mʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ム,mu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,メ,me,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,モ,mo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ヤ,ja,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ユ,juː,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ヨ,jo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ラ,ɾa],,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,リ,ɾʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ル,ɾu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,レ,ɾe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ロ,ɾo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ワ,ɰa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ウェ,ɰo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ン,/N/,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,パ,pa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ピ,pʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,プ,pu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ペ,pe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ポ,po,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,チャ,t͡ɕʲa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,チェ,tʃe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,チョ,t͡ɕʲo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ァ,-a,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ィ,-i,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ゥ,-u,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ェ,-e,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ォ,-o,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇰ,-k̚,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇱ,-ɕ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇲ,-ɕ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ッ,-t̚,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇳ,-t̚,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇴ,-n,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇵ,-h,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇷ゚,-p,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇶ,-ç,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇷ,-ɸ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇸ,-he,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇹ,-ho,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇺ,-m,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇻ,-ra,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇼ,-li,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇽ,-ru,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇿ,-lo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ㇾ,-le,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,セ゚,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ツ゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
-Ainu Katakana,ト゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Tigre (Abjad),آ,ʔ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ا,∅,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـا,ʔ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـا,∅,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),آ,∅,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ا,ʔ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـا,∅,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـا,ʔ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ب,b,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـب,b,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),بـ,b,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـبـ,b,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),پ,p,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـپ,p,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),پـ,p,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـپـ,p,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ت,t̪,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـت,t̪,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),تـ,t̪,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـتـ,t̪,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ث,s,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـث,s,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ثـ,s,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـثـ,s,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ج,d͡ʒ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـج,d͡ʒ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),جـ,d͡ʒ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـجـ,d͡ʒ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ح,ħ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـح,ħ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),حـ,ħ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـحـ,ħ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),خ,x,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـخ,x,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),خـ,x,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـخـ,x,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),د,d̪,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـد,d̪,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),د,d̪,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـد,d̪,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ذ,z,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـذ,z,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ذ,z,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـذ,z,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ر,r,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـر,r,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ر,r,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـر,r,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ز,z,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـز,z,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ز,z,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـز,z,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ژ,ʒ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـژ,ʒ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),-,,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),-,,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),س,s,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـس,s,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),سـ,s,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـسـ,s,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ش,ʃ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـش,ʃ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),شـ,ʃ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـشـ,ʃ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ڛ,tʃ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),‍ڛ,tʃ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ڛ‍,tʃ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),‍ڛ‍,tʃ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ص,s',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـص,s',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),صـ,s',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـصـ,s',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ض,d,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـض,d,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ضـ,d,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـضـ,d,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ط,t',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـط,t',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),طـ,t',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـطـ,t',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ظ,z,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـظ,z,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ظـ,z,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـظـ,z,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ڟ,tʃ’,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـڟ,tʃ’,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ڟـ,tʃ’,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـڟـ,tʃ’,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ع,ʕ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـع,ʕ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),عـ,ʕ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـعـ,ʕ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),غ,ɡ,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـغ,ɡ,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),غـ,ɡ,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـغـ,ɡ,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ف,f,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـف,f,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),فـ,f,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـفـ,f,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ڥ,p',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـڥ,p',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـڥـ,p',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ڥـ,p',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ق,k',isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـق,k',final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),قـ,k',initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـقـ,k',medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ك,k,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـ‍ك‎,k,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),كـ‍,k,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـ‍ك‍ـ,k,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ل,l,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـل,l,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),لـ,l,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـلـ,l,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),م,m,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـم,m,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),مـ,m,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـمـ,m,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ن,n,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـن,n,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),نـ,n,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـنـ,n,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),و,w,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),و,w,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),و,w,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),-,,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ه,h,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـه,h,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),هـ,h,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـهـ,h,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ي,j,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـي,j,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),يـ,j,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ـيـ,j,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ِي,e,isolated,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ِـي,e,final,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ِيـ,e,initial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ِـيـ,e,medial,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ُو,o,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),"آ, َا",a:,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ْ,ɨ,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ْ,∅,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ُ,u,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),ِ,i,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Tigre (Abjad),َ,ɐ,,Raz 1983,http://www.omniglot.com/writing/tigre.htm
+Ainu (Latin),a,a,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),i,i,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),u,ɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),e,e,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),o,o,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ka,ka,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ki,kʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ku,kɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ke,ke,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ko,ko,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),sa,ʃa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),si,ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),su,sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),se,se,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),so,so,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ta,ta,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ci,t͡ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),tu,t͡sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),te,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),to,to,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),,,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ni,ɲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),nu,nɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ne,ne,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),no,no,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ha,ha,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),hi,çi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),hu,ɸɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),he,he,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ho,ho,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ma,ma,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),mi,mʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),mu,mɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),me,me,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),mo,mo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ya,ja,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),yu,jɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ye,je,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),yo,jo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ra,ɾa],,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ri,ɾʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ru,ɾɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),re,ɾe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ro,ɾo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),wa,ɰa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),we,ɰe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),wo,ɰo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),n,/N/,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),pa,pa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),pi,pʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),pu,pɯ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),pe,pe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),po,po,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ca,t͡ɕʲa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),cu,t͡ɕʲɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Latin),ce,t͡ɕʲo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ア,a,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),イ,i,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ウ,u,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),エ,e,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),オ,o,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),カ,ka,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),キ,kʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ク,ku,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ケ,ke,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),コ,ko,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),サ,ʃa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),シ,ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ス,sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),セ,se,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ソ,so,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),タ,ta,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),チ,t͡ɕi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),トゥ,t͡sɨ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),テ,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ト,to,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ナ,,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ニ,ɲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ヌ,nu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ネ,ne,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ノ,no,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ハ,ha,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ヒ,çi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),フ,ɸu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ヘ,he,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ホ,ho,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),マ,ma,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ミ,mʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ム,mu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),メ,me,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),モ,mo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ヤ,ja,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ユ,juː,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ヨ,jo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ラ,ɾa],,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),リ,ɾʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ル,ɾu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),レ,ɾe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ロ,ɾo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ワ,ɰa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ウェ,ɰo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ン,/N/,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),パ,pa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ピ,pʲi,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),プ,pu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ペ,pe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ポ,po,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),チャ,t͡ɕʲa,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),チェ,tʃe,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),チョ,t͡ɕʲo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ァ,-a,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ィ,-i,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ゥ,-u,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ェ,-e,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ォ,-o,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇰ,-k̚,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇱ,-ɕ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇲ,-ɕ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ッ,-t̚,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇳ,-t̚,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇴ,-n,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇵ,-h,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇷ゚,-p,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇶ,-ç,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇷ,-ɸ,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇸ,-he,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇹ,-ho,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇺ,-m,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇻ,-ra,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇼ,-li,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇽ,-ru,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇿ,-lo,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ㇾ,-le,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),セ゚,te,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ツ゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
+Ainu (Katakana),ト゚,tu,,Everhart 2009,https://www.omniglot.com/writing/ainu.htm
 Aymara,A,a,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
 Aymara,Ä,aː,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
 Aymara,Ch,ʧ,,"[Hardman, Vásquez, de Dios Yapita 1971]",https://www.omniglot.com/writing/aymara.htm
@@ -15472,95 +15472,95 @@ Erzya,Я,ja,,Аитов 1932,http://www.omniglot.com/writing/erzya.htm
 Erzya,я,ja,,Аитов 1932,http://www.omniglot.com/writing/erzya.htm
 Erzya,Я,ʲa,,Аитов 1932,http://www.omniglot.com/writing/erzya.htm
 Erzya,я,ʲa,,Аитов 1932,http://www.omniglot.com/writing/erzya.htm
-Nganasan,А,ɐ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,а,ɐ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Б,b,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,б,b,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,В,v,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,в,v,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Г,ɡ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,г,ɡ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Д,d,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,д,d,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Е,je,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,е,je,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Е,ʲe,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,е,ʲe,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ё,jo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ё,jo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ё,ʲo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ё,ʲo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ж,ʒ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ж,ʒ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,З,z,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,з,z,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,З̌,ð,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,з̌,ð,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,И,ʲi:,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,и,ʲi:,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,И,i,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,и,i,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Й,j,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,й,j,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,’’,ʔ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,К,k,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,к,k,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Л,l,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,л,l,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,М,m,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,м,m,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Н,n,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,н,n,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ӈ,ŋ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ӈ,ŋ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,О,o,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,о,o,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ө,wа,w надстрочный,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ө,wа,w надстрочный,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,П,p,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,п,p,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Р,r,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,р,r,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,С,s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,с,s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ç,θ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ç,θ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Т,t,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,т,t,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,У,u,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,у,u,Үү = ʲy; y,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ф,f,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ф,f,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Х,x,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,х,x,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Х,h,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,х,h,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ц,t͡s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ц,t͡s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ч,t͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ч,t͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ш,ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ш,ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Щ,ʃt͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,щ,ʃt͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ъ,-,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ъ,-,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ы,ɨ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ы,ɨ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ь,◌ʲ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ь,◌ʲ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Э,e,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,э,e,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ә,ǝ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ә,ǝ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ю,ju,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ю,ju,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Ю,ʲu,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,ю,ʲu,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Я,ja,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,я,ja,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,Я,ʲa,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
-Nganasan,я,ʲa,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,А,ɐ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,а,ɐ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Б,b,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,б,b,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,В,v,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,в,v,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Г,ɡ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,г,ɡ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Д,d,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,д,d,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Е,je,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,е,je,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Е,ʲe,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,е,ʲe,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ё,jo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ё,jo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ё,ʲo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ё,ʲo,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ж,ʒ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ж,ʒ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,З,z,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,з,z,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,З̌,ð,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,з̌,ð,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,И,ʲi:,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,и,ʲi:,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,И,i,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,и,i,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Й,j,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,й,j,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,’’,ʔ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,К,k,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,к,k,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Л,l,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,л,l,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,М,m,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,м,m,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Н,n,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,н,n,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ӈ,ŋ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ӈ,ŋ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,О,o,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,о,o,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ө,wа,w надстрочный,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ө,wа,w надстрочный,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,П,p,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,п,p,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Р,r,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,р,r,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,С,s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,с,s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ç,θ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ç,θ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Т,t,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,т,t,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,У,u,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,у,u,Үү = ʲy; y,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ф,f,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ф,f,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Х,x,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,х,x,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Х,h,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,х,h,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ц,t͡s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ц,t͡s,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ч,t͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ч,t͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ш,ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ш,ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Щ,ʃt͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,щ,ʃt͡ʃ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ъ,-,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ъ,-,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ы,ɨ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ы,ɨ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ь,◌ʲ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ь,◌ʲ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Э,e,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,э,e,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ә,ǝ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ә,ǝ,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ю,ju,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ю,ju,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Ю,ʲu,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,ю,ʲu,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Я,ja,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,я,ja,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,Я,ʲa,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
+Nganasan 2,я,ʲa,,Жовницкая-Турдагина 1999,http://www.omniglot.com/writing/nganasan.htm
 Udmurt,А,a,,Тараканов 2000,http://www.omniglot.com/writing/udmurt.htm
 Udmurt,а,a,,Тараканов 2000,http://www.omniglot.com/writing/udmurt.htm
 Udmurt,Б,b,,Тараканов 2000,http://www.omniglot.com/writing/udmurt.htm
@@ -17014,46 +17014,46 @@ Mongolian,ᡀ‍,lh,"loanwords only, initial",Bat-Ireedui 2015: 213-214,http://o
 Mongolian,‍ᡀ‍,lh,"loanwords only, medial",Bat-Ireedui 2015: 213-214,http://omniglot.com/writing/mongolian.htm 
 Mongolian,ᡁ‍,zh,loanwords only,Bat-Ireedui 2015: 213-214,http://omniglot.com/writing/mongolian.htm 
 Mongolian,ᡂ‍,ch,loanwords only,Bat-Ireedui 2015: 213-214,http://omniglot.com/writing/mongolian.htm 
-Persian Braille,⠜,aː,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠁,aː,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠁,a,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠁,e,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠁,o,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠃,b,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠏,p,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠞,t,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠹,s,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠚,dʒ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠉,tʃ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠱,h,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠭,x,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠙,d,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠮,z,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠗,r,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠵,z,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠬,ʒ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠎,s,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠩,ʃ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠯,s,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠫,z,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠾,t,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠿,z,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠷,ʔ,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠣,q,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠋,f,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠟,ɣ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠅,k,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠛,ɡ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠇,l,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠍,m,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠝,n,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠺,u,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠺,v,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠓,h,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠓,e,final,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
-Persian Braille,⠊,i,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠊,j,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
-Persian Braille,⠕,a,"final, Arabic loanwords only",UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠜,aː,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠁,aː,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠁,a,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠁,e,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠁,o,initial,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠃,b,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠏,p,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠞,t,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠹,s,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠚,dʒ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠉,tʃ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠱,h,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠭,x,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠙,d,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠮,z,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠗,r,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠵,z,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠬,ʒ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠎,s,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠩,ʃ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠯,s,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠫,z,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠾,t,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠿,z,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠷,ʔ,Arabic loanwords only,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠣,q,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠋,f,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠟,ɣ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠅,k,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠛,ɡ,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠇,l,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠍,m,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠝,n,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠺,u,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠺,v,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠓,h,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠓,e,final,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
+Persian (Braille),⠊,i,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠊,j,,UNESCO 2013: 71,https://omniglot.com/writing/braille.htm
+Persian (Braille),⠕,a,"final, Arabic loanwords only",UNESCO 2013: 71,https://omniglot.com/writing/braille.htm 
 Itbayat,A,a,,Hidalgo 1971,https://www.omniglot.com/writing/itbayat.htm
 Itbayat,a,a,,Hidalgo 1971,https://www.omniglot.com/writing/itbayat.htm
 Itbayat,B,b,,Hidalgo 1971,https://www.omniglot.com/writing/itbayat.htm
@@ -18442,170 +18442,170 @@ Nukuoro,U,u,,Carroll 1965,https://www.omniglot.com/writing/nukuoro.htm
 Nukuoro,u,u,,Carroll 1965,https://www.omniglot.com/writing/nukuoro.htm
 Nukuoro,V,v,,Carroll 1965,https://www.omniglot.com/writing/nukuoro.htm
 Nukuoro,v,v,,Carroll 1965,https://www.omniglot.com/writing/nukuoro.htm
-Rutul Latin,a,ɑ,,"Clarkson, Iurkova 2015",
-Rutul Latin,aI,ɑˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
-Rutul Latin,ə,æ,,"Clarkson, Iurkova 2015",
-Rutul Latin,b,b,,"Clarkson, Iurkova 2015",
-Rutul Latin,v,ʋ,,"Clarkson, Iurkova 2015",
-Rutul Latin,g,ɡ,,"Clarkson, Iurkova 2015",
-Rutul Latin,h,h,,"Clarkson, Iurkova 2015",
-Rutul Latin,ğ,ʁ,,"Clarkson, Iurkova 2015",
-Rutul Latin,gh,ɣ,,"Clarkson, Iurkova 2015",
-Rutul Latin,d,d,,"Clarkson, Iurkova 2015",
-Rutul Latin,c,d͡ʒ,,"Clarkson, Iurkova 2015",
-Rutul Latin,e,e,,"Clarkson, Iurkova 2015",
-Rutul Latin,j,ʒ,,"Clarkson, Iurkova 2015",
-Rutul Latin,z,z,,"Clarkson, Iurkova 2015",
-Rutul Latin,i,i,,"Clarkson, Iurkova 2015",
-Rutul Latin,y,j,,"Clarkson, Iurkova 2015",
-Rutul Latin,k,k,,"Clarkson, Iurkova 2015",
-Rutul Latin,q`,q',,"Clarkson, Iurkova 2015",
-Rutul Latin,q,ɢ,,"Clarkson, Iurkova 2015",
-Rutul Latin,k`,k',,"Clarkson, Iurkova 2015",
-Rutul Latin,l,l,,"Clarkson, Iurkova 2015",
-Rutul Latin,m,m,,"Clarkson, Iurkova 2015",
-Rutul Latin,n,n,,"Clarkson, Iurkova 2015",
-Rutul Latin,o,o,,"Clarkson, Iurkova 2015",
-Rutul Latin,p,p,,"Clarkson, Iurkova 2015",
-Rutul Latin,p`,p',,"Clarkson, Iurkova 2015",
-Rutul Latin,r,r,,"Clarkson, Iurkova 2015",
-Rutul Latin,s,s,,"Clarkson, Iurkova 2015",
-Rutul Latin,t,t,,"Clarkson, Iurkova 2015",
-Rutul Latin,t`,t',,"Clarkson, Iurkova 2015",
-Rutul Latin,u,u,,"Clarkson, Iurkova 2015",
-Rutul Latin,ü,y,,"Clarkson, Iurkova 2015",
-Rutul Latin,uI,uˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
-Rutul Latin,f,f,,"Clarkson, Iurkova 2015",
-Rutul Latin,x,χ,,"Clarkson, Iurkova 2015",
-Rutul Latin,xh,x,,"Clarkson, Iurkova 2015",
-Rutul Latin,qh,q,,"Clarkson, Iurkova 2015",
-Rutul Latin,ts,t͡s,,"Clarkson, Iurkova 2015",
-Rutul Latin,ts`,t͡s',,"Clarkson, Iurkova 2015",
-Rutul Latin,ç,t͡ʃ,,"Clarkson, Iurkova 2015",
-Rutul Latin,ç`,t͡ʃ',,"Clarkson, Iurkova 2015",
-Rutul Latin,ş,ʃ,,"Clarkson, Iurkova 2015",
-Rutul Latin,`,ʔ,,"Clarkson, Iurkova 2015",
-Rutul Latin,ı,ɨ,,"Clarkson, Iurkova 2015",
-Rutul Latin,ıI,ɨˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
-Rutul Latin,A,ɑ,,"Clarkson, Iurkova 2015",
-Rutul Latin,AI,ɑˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
-Rutul Latin,Ə,æ,,"Clarkson, Iurkova 2015",
-Rutul Latin,B,b,,"Clarkson, Iurkova 2015",
-Rutul Latin,V,ʋ,,"Clarkson, Iurkova 2015",
-Rutul Latin,G,ɡ,,"Clarkson, Iurkova 2015",
-Rutul Latin,H,h,,"Clarkson, Iurkova 2015",
-Rutul Latin,Ğ,ʁ,,"Clarkson, Iurkova 2015",
-Rutul Latin,Gh,ɣ,,"Clarkson, Iurkova 2015",
-Rutul Latin,D,d,,"Clarkson, Iurkova 2015",
-Rutul Latin,C,d͡ʒ,,"Clarkson, Iurkova 2015",
-Rutul Latin,E,e,,"Clarkson, Iurkova 2015",
-Rutul Latin,J,ʒ,,"Clarkson, Iurkova 2015",
-Rutul Latin,Z,z,,"Clarkson, Iurkova 2015",
-Rutul Latin,I,i,,"Clarkson, Iurkova 2015",
-Rutul Latin,Y,j,,"Clarkson, Iurkova 2015",
-Rutul Latin,K,k,,"Clarkson, Iurkova 2015",
-Rutul Latin,Q`,q',,"Clarkson, Iurkova 2015",
-Rutul Latin,Q,ɢ,,"Clarkson, Iurkova 2015",
-Rutul Latin,K`,k',,"Clarkson, Iurkova 2015",
-Rutul Latin,L,l,,"Clarkson, Iurkova 2015",
-Rutul Latin,M,m,,"Clarkson, Iurkova 2015",
-Rutul Latin,N,n,,"Clarkson, Iurkova 2015",
-Rutul Latin,O,o,,"Clarkson, Iurkova 2015",
-Rutul Latin,P,p,,"Clarkson, Iurkova 2015",
-Rutul Latin,P`,p',,"Clarkson, Iurkova 2015",
-Rutul Latin,R,r,,"Clarkson, Iurkova 2015",
-Rutul Latin,S,s,,"Clarkson, Iurkova 2015",
-Rutul Latin,T,t,,"Clarkson, Iurkova 2015",
-Rutul Latin,T`,t',,"Clarkson, Iurkova 2015",
-Rutul Latin,U,u,,"Clarkson, Iurkova 2015",
-Rutul Latin,Ü,y,,"Clarkson, Iurkova 2015",
-Rutul Latin,UI,uˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
-Rutul Latin,F,f,,"Clarkson, Iurkova 2015",
-Rutul Latin,X,χ,,"Clarkson, Iurkova 2015",
-Rutul Latin,Xh,x,,"Clarkson, Iurkova 2015",
-Rutul Latin,Qh,q,,"Clarkson, Iurkova 2015",
-Rutul Latin,Ts,t͡s,,"Clarkson, Iurkova 2015",
-Rutul Latin,Ts`,t͡s',,"Clarkson, Iurkova 2015",
-Rutul Latin,Ç,t͡ʃ,,"Clarkson, Iurkova 2015",
-Rutul Latin,Ç`,t͡ʃ',,"Clarkson, Iurkova 2015",
-Rutul Latin,Ş,ʃ,,"Clarkson, Iurkova 2015",
-Rutul Latin,I,ɨ,,"Clarkson, Iurkova 2015",
-Rutul Latin,II,ɨˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
-Ndyuka Latin,a,a,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,aa,aː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,b,b,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,d,d,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,e,e,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,ee,eː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,f,f,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,g,ɡ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,h,h,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,i,i,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,ii,iː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,k,k,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,l,l,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,m,m,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,n,n,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,o,o,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,oo,oː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,p,p,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,s,s,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,t,t,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,u,u,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,uu,uː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,w,w,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,y,j,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,z,z,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,dy,d͡ʒ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,ny,ɲ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,sy,ʃ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Ndyuka Latin,ty,t͡ʃ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
-Rutul Cyrillic,А,ɑ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,АI,ɑˤ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Аь,æ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Б,b,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,В,ʋ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Г,ɡ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Гь,h,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Гъ,ʁ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,ГI,ɣ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Д,d,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Дж,d͡ʒ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Дз,d͡z,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Е,e,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ж,ʒ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,З,z,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,И,i,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Й,j,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,К,k,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Кь,q',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Къ,ɢ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,КI,k',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Л,l,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,М,m,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Н,n,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,О,o,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,П,p,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,ПI,p',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Р,r,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,С,s,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Т,t,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,ТI,t',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,У,u,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Уь,y,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,УI,uˤ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ф,f,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Х,χ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Хь,x,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Хъ,q,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ц,t͡s,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,ЦI,t͡s',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ч,t͡ʃ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,ЧI,t͡ʃ',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ш,ʃ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ъ,ʔ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,Ы,ɨ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
-Rutul Cyrillic,ЫI,ɨˤ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Latin),a,ɑ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),aI,ɑˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
+Rutul (Latin),ə,æ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),b,b,,"Clarkson, Iurkova 2015",
+Rutul (Latin),v,ʋ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),g,ɡ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),h,h,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ğ,ʁ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),gh,ɣ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),d,d,,"Clarkson, Iurkova 2015",
+Rutul (Latin),c,d͡ʒ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),e,e,,"Clarkson, Iurkova 2015",
+Rutul (Latin),j,ʒ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),z,z,,"Clarkson, Iurkova 2015",
+Rutul (Latin),i,i,,"Clarkson, Iurkova 2015",
+Rutul (Latin),y,j,,"Clarkson, Iurkova 2015",
+Rutul (Latin),k,k,,"Clarkson, Iurkova 2015",
+Rutul (Latin),q`,q',,"Clarkson, Iurkova 2015",
+Rutul (Latin),q,ɢ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),k`,k',,"Clarkson, Iurkova 2015",
+Rutul (Latin),l,l,,"Clarkson, Iurkova 2015",
+Rutul (Latin),m,m,,"Clarkson, Iurkova 2015",
+Rutul (Latin),n,n,,"Clarkson, Iurkova 2015",
+Rutul (Latin),o,o,,"Clarkson, Iurkova 2015",
+Rutul (Latin),p,p,,"Clarkson, Iurkova 2015",
+Rutul (Latin),p`,p',,"Clarkson, Iurkova 2015",
+Rutul (Latin),r,r,,"Clarkson, Iurkova 2015",
+Rutul (Latin),s,s,,"Clarkson, Iurkova 2015",
+Rutul (Latin),t,t,,"Clarkson, Iurkova 2015",
+Rutul (Latin),t`,t',,"Clarkson, Iurkova 2015",
+Rutul (Latin),u,u,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ü,y,,"Clarkson, Iurkova 2015",
+Rutul (Latin),uI,uˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
+Rutul (Latin),f,f,,"Clarkson, Iurkova 2015",
+Rutul (Latin),x,χ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),xh,x,,"Clarkson, Iurkova 2015",
+Rutul (Latin),qh,q,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ts,t͡s,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ts`,t͡s',,"Clarkson, Iurkova 2015",
+Rutul (Latin),ç,t͡ʃ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ç`,t͡ʃ',,"Clarkson, Iurkova 2015",
+Rutul (Latin),ş,ʃ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),`,ʔ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ı,ɨ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),ıI,ɨˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
+Rutul (Latin),A,ɑ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),AI,ɑˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ə,æ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),B,b,,"Clarkson, Iurkova 2015",
+Rutul (Latin),V,ʋ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),G,ɡ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),H,h,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ğ,ʁ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Gh,ɣ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),D,d,,"Clarkson, Iurkova 2015",
+Rutul (Latin),C,d͡ʒ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),E,e,,"Clarkson, Iurkova 2015",
+Rutul (Latin),J,ʒ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Z,z,,"Clarkson, Iurkova 2015",
+Rutul (Latin),I,i,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Y,j,,"Clarkson, Iurkova 2015",
+Rutul (Latin),K,k,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Q`,q',,"Clarkson, Iurkova 2015",
+Rutul (Latin),Q,ɢ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),K`,k',,"Clarkson, Iurkova 2015",
+Rutul (Latin),L,l,,"Clarkson, Iurkova 2015",
+Rutul (Latin),M,m,,"Clarkson, Iurkova 2015",
+Rutul (Latin),N,n,,"Clarkson, Iurkova 2015",
+Rutul (Latin),O,o,,"Clarkson, Iurkova 2015",
+Rutul (Latin),P,p,,"Clarkson, Iurkova 2015",
+Rutul (Latin),P`,p',,"Clarkson, Iurkova 2015",
+Rutul (Latin),R,r,,"Clarkson, Iurkova 2015",
+Rutul (Latin),S,s,,"Clarkson, Iurkova 2015",
+Rutul (Latin),T,t,,"Clarkson, Iurkova 2015",
+Rutul (Latin),T`,t',,"Clarkson, Iurkova 2015",
+Rutul (Latin),U,u,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ü,y,,"Clarkson, Iurkova 2015",
+Rutul (Latin),UI,uˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
+Rutul (Latin),F,f,,"Clarkson, Iurkova 2015",
+Rutul (Latin),X,χ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Xh,x,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Qh,q,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ts,t͡s,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ts`,t͡s',,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ç,t͡ʃ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ç`,t͡ʃ',,"Clarkson, Iurkova 2015",
+Rutul (Latin),Ş,ʃ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),I,ɨ,,"Clarkson, Iurkova 2015",
+Rutul (Latin),II,ɨˤ,это предлагаемое обозначение фарингализации; все возможмные варианты: V1/V!/Vİ/Vı,"Clarkson, Iurkova 2015",
+Ndyuka (Latin),a,a,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),aa,aː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),b,b,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),d,d,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),e,e,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),ee,eː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),f,f,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),g,ɡ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),h,h,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),i,i,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),ii,iː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),k,k,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),l,l,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),m,m,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),n,n,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),o,o,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),oo,oː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),p,p,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),s,s,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),t,t,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),u,u,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),uu,uː,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),w,w,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),y,j,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),z,z,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),dy,d͡ʒ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),ny,ɲ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),sy,ʃ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Ndyuka (Latin),ty,t͡ʃ,,"Hutter, Hutter 1994",http://www.omniglot.com/writing/ndjuka.htm
+Rutul (Cyrillic),А,ɑ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),АI,ɑˤ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Аь,æ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Б,b,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),В,ʋ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Г,ɡ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Гь,h,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Гъ,ʁ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),ГI,ɣ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Д,d,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Дж,d͡ʒ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Дз,d͡z,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Е,e,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ж,ʒ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),З,z,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),И,i,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Й,j,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),К,k,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Кь,q',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Къ,ɢ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),КI,k',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Л,l,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),М,m,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Н,n,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),О,o,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),П,p,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),ПI,p',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Р,r,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),С,s,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Т,t,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),ТI,t',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),У,u,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Уь,y,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),УI,uˤ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ф,f,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Х,χ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Хь,x,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Хъ,q,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ц,t͡s,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),ЦI,t͡s',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ч,t͡ʃ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),ЧI,t͡ʃ',,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ш,ʃ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ъ,ʔ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),Ы,ɨ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
+Rutul (Cyrillic),ЫI,ɨˤ,,"Clarkson, Iurkova 2015",http://www.omniglot.com/writing/rutul.htm
 Ingush,а,a,,Nichols 2011,http://www.omniglot.com/writing/ingush.htm
 Ingush,а,aː,,Nichols 2011,http://www.omniglot.com/writing/ingush.htm
 Ingush,аь,æ,,Nichols 2011,http://www.omniglot.com/writing/ingush.htm


### PR DESCRIPTION
@agricolamz -- this PR:

- adds glottolog codes to `bibliography.csv`
- adds iso15924 writing systems codes to `bibliography.csv`
- corrects typos in language names, e.g. Tadjik -> Tajik
- fixes omniglot urls (some pointed to latin or cyrillic, instead of actual the language pages)
- unifies omniglot urls (now all https)
- adds missing omniglot urls
- fixes incorrect omniglot urls, e.g.

Sarcee,e,e,,Cook 1984: 7-10,https://www.omniglot.com/writing/sarcee.htm
Sarcee,i,i,,Cook 1984: 7-10,https://www.omniglot.com/writing/tsuutina.htm

- unifies script names (e.g. language 1, language2 for multiple entries; language (script) when multiple scripts)
- orders `bibliography.csv` alphabetically
- removes quotes in references in `bibliography.csv`
- unifies bib entries for single languages, e.g. Aghul, Aghul -> Aghul (single entry now has two references)

Next, I will:

- regen the omniglot codes in `database.csv` from the `bibliography.csv`, so that they match
